### PR TITLE
Modernize Hugo template idioms (site/absURL)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-hugo-template-modernization.md
+++ b/docs/superpowers/plans/2026-06-30-hugo-template-modernization.md
@@ -1,0 +1,555 @@
+# Hugo Template Modernization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `.Site.X` template access with the global `site` function,
+and raw `.Site.BaseURL` string concatenation with `absURL`, across the
+vendored `portio` theme — zero change to rendered output.
+
+**Architecture:** Mechanical, file-by-file template edits in
+`themes/portio/layouts`. Each task is verified the same way: build the site
+with `hugo` before the edit, capture the specific generated page(s) that
+template touches, make the edit, rebuild, and diff — expect byte-identical
+output.
+
+**Tech Stack:** Hugo 0.157.0 static site generator (Go templates). No test
+framework — Hugo's own build output is the test oracle.
+
+## Global Constraints
+
+- No change to any rendered HTML/CSS/JS output (see spec's Non-goals).
+- Scope is exactly these 8 files under `themes/portio/layouts`: `partials/
+  navbar.html`, `partials/footer.html`, `partials/head.html`, `partials/
+  blogSection.html`, `partials/portfolioSection.html`, `blog/list.html`,
+  `blog/single.html`, `contact/list.html`. Do not touch SCSS, Bootstrap, JS,
+  `themes/portio/exampleSite`, `data/*.yml`, or `content/*.md`.
+- `hugo` must be run from the repo root (`/Users/rod/build/begbie-hugo`); it
+  reads `config.toml` and writes to `public/` (gitignored, safe to
+  overwrite).
+
+---
+
+## Task 1: Modernize global chrome partials (head, navbar, footer)
+
+**Files:**
+
+- Modify: `themes/portio/layouts/partials/head.html:8`
+- Modify: `themes/portio/layouts/partials/navbar.html` (whole file)
+- Modify: `themes/portio/layouts/partials/footer.html:40,48,55,65,81,87,99`
+
+These three partials are included by `themes/portio/layouts/_default/
+baseof.html` and render on every page, so verification diffs the entire
+`public/` tree.
+
+- [ ] **Step 1: Capture baseline output for the whole site**
+
+```bash
+hugo
+BASELINE=$(mktemp -d)
+cp -R public "$BASELINE/public-before"
+echo "$BASELINE"
+```
+
+Keep the printed `$BASELINE` path — you'll need it in step 3.
+
+- [ ] **Step 2: Edit `head.html`**
+
+Replace:
+
+```html
+{{- with .Description | default .Params.subtitle | default .Site.Params.subtitle | default .Summary }}
+```
+
+With:
+
+```html
+{{- with .Description | default .Params.subtitle | default site.Params.subtitle | default .Summary }}
+```
+
+- [ ] **Step 3: Edit `navbar.html`**
+
+Replace the whole file:
+
+```html
+<nav class="navbar navbar-expand-lg fixed-top">
+  <div class="container">
+    <a href="{{ .Site.BaseURL }}" class="navbar-brand">
+      <!-- <img src="{{ .Site.Params.logo | absURL }}" alt="site-logo"> -->
+      Rod Begbie
+    </a>
+    <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#navbarCollapse">
+      <span class="navbar-toggler-icon"></span>
+      <span class="navbar-toggler-icon"></span>
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse justify-content-between" id="navbarCollapse">
+      <ul class="nav navbar-nav main-navigation my-0 mx-auto">
+        {{ $menu := .Site.Menus.main }}
+        {{ range $index, $element := $menu }}
+        <li class="nav-item">
+          <a href="{{ $.Site.BaseURL }}{{ .URL }}"
+            class="nav-link text-dark text-sm-center p-2 {{ if $.IsHome }}scroll{{ end }}">{{ .Name }}</a>
+        </li>
+        {{ end }}
+      </ul>
+      <div class="navbar-nav">
+        <a href="{{ $.Site.BaseURL }}#contact" class="btn btn-primary btn-zoom hire_button">Work With Me</a>
+      </div>
+    </div>
+  </div>
+</nav>
+```
+
+With:
+
+```html
+<nav class="navbar navbar-expand-lg fixed-top">
+  <div class="container">
+    <a href="{{ "" | absURL }}" class="navbar-brand">
+      <!-- <img src="{{ site.Params.logo | absURL }}" alt="site-logo"> -->
+      Rod Begbie
+    </a>
+    <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#navbarCollapse">
+      <span class="navbar-toggler-icon"></span>
+      <span class="navbar-toggler-icon"></span>
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse justify-content-between" id="navbarCollapse">
+      <ul class="nav navbar-nav main-navigation my-0 mx-auto">
+        {{ range $index, $element := site.Menus.main }}
+        <li class="nav-item">
+          <a href="{{ .URL | absURL }}"
+            class="nav-link text-dark text-sm-center p-2 {{ if $.IsHome }}scroll{{ end }}">{{ .Name }}</a>
+        </li>
+        {{ end }}
+      </ul>
+      <div class="navbar-nav">
+        <a href="{{ "#contact" | absURL }}" class="btn btn-primary btn-zoom hire_button">Work With Me</a>
+      </div>
+    </div>
+  </div>
+</nav>
+```
+
+- [ ] **Step 4: Edit `footer.html`**
+
+Replace each of these seven lines individually (they're not contiguous —
+three are inside the commented-out sitemap/address widget block, which is
+still template-evaluated even though it renders as an HTML comment):
+
+Line 40, replace:
+
+```html
+<a class="btn btn-light btn-zoom" href="{{ .Site.Params.contactLink | absURL }}">Email me</a>
+```
+
+With:
+
+```html
+<a class="btn btn-light btn-zoom" href="{{ site.Params.contactLink | absURL }}">Email me</a>
+```
+
+Line 48, replace:
+
+```html
+<img src="{{ .Site.Params.footerLogo | absURL }}" alt="widget-logo">
+```
+
+With:
+
+```html
+<img src="{{ site.Params.footerLogo | absURL }}" alt="widget-logo">
+```
+
+Line 55, replace:
+
+```html
+{{ $sitemap := .Site.Menus.sitemap }}
+```
+
+With:
+
+```html
+{{ $sitemap := site.Menus.sitemap }}
+```
+
+Line 65, replace:
+
+```html
+{{ $address := .Site.Params.address }}
+```
+
+With:
+
+```html
+{{ $address := site.Params.address }}
+```
+
+Line 81, replace:
+
+```html
+<p>{{ .Site.Params.copyright }}</p>
+```
+
+With:
+
+```html
+<p>{{ site.Params.copyright }}</p>
+```
+
+Line 87, replace:
+
+```html
+{{ $social := .Site.Params.social }}
+```
+
+With:
+
+```html
+{{ $social := site.Params.social }}
+```
+
+Line 99, replace:
+
+```html
+<!-- <script src="https://maps.googleapis.com/maps/api/js?key={{ .Site.Params.map.APIkey }}&libraries=geometry"></script> -->
+```
+
+With:
+
+```html
+<!-- <script src="https://maps.googleapis.com/maps/api/js?key={{ site.Params.map.APIkey }}&libraries=geometry"></script> -->
+```
+
+- [ ] **Step 5: Verify no `.Site` references remain in these three files**
+
+```bash
+grep -n '\.Site\b' themes/portio/layouts/partials/head.html \
+  themes/portio/layouts/partials/navbar.html \
+  themes/portio/layouts/partials/footer.html
+```
+
+Expected: no output (no matches).
+
+- [ ] **Step 6: Rebuild and diff the whole site against the baseline**
+
+```bash
+hugo
+diff -rq "$BASELINE/public-before" public
+```
+
+Expected: no output (identical trees). If there's a difference, stop and
+investigate before continuing — do not proceed to Task 2 with an unexplained
+diff.
+
+- [ ] **Step 7: Clean up and commit**
+
+```bash
+rm -rf "$BASELINE"
+git add themes/portio/layouts/partials/head.html \
+  themes/portio/layouts/partials/navbar.html \
+  themes/portio/layouts/partials/footer.html
+git commit -m "Modernize global chrome partials to site/absURL"
+```
+
+---
+
+## Task 2: Modernize homepage section partials (blogSection, portfolioSection)
+
+**Files:**
+
+- Modify: `themes/portio/layouts/partials/blogSection.html:23`
+- Modify: `themes/portio/layouts/partials/portfolioSection.html:16`
+
+Both partials are only rendered on the homepage
+(`themes/portio/layouts/index.html`), so verification diffs `public/
+index.html`. Note `portfolioSection` is currently disabled
+(`data/portfolioSection.yml` has `enable: false`), so its body doesn't
+render at all right now — the edit still matters for correctness the day it
+gets re-enabled, and the diff should show zero change either way.
+
+- [ ] **Step 1: Capture baseline output for the homepage**
+
+```bash
+hugo
+BASELINE=$(mktemp -d)
+cp public/index.html "$BASELINE/index.html.before"
+echo "$BASELINE"
+```
+
+- [ ] **Step 2: Edit `blogSection.html`**
+
+Replace:
+
+```html
+{{ range first 3 (where $.Site.RegularPages "Type" "!=" "portfolio") }}
+```
+
+With:
+
+```html
+{{ range first 3 (where site.RegularPages "Type" "!=" "portfolio") }}
+```
+
+- [ ] **Step 3: Edit `portfolioSection.html`**
+
+Replace:
+
+```html
+{{ range (where $.Site.RegularPages "Type" "portfolio").Reverse }}
+```
+
+With:
+
+```html
+{{ range (where site.RegularPages "Type" "portfolio").Reverse }}
+```
+
+- [ ] **Step 4: Verify no `.Site` references remain in these two files**
+
+```bash
+grep -n '\.Site\b' themes/portio/layouts/partials/blogSection.html \
+  themes/portio/layouts/partials/portfolioSection.html
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Rebuild and diff the homepage against the baseline**
+
+```bash
+hugo
+diff "$BASELINE/index.html.before" public/index.html
+```
+
+Expected: no output. If there's a difference, stop and investigate.
+
+- [ ] **Step 6: Clean up and commit**
+
+```bash
+rm -rf "$BASELINE"
+git add themes/portio/layouts/partials/blogSection.html \
+  themes/portio/layouts/partials/portfolioSection.html
+git commit -m "Modernize homepage section partials to site.RegularPages"
+```
+
+---
+
+## Task 3: Modernize blog templates (list, single)
+
+**Files:**
+
+- Modify: `themes/portio/layouts/blog/list.html:30`
+- Modify: `themes/portio/layouts/blog/single.html:10-11`
+
+Verification diffs the blog index page and one representative post page.
+
+- [ ] **Step 1: Capture baseline output for the blog pages**
+
+```bash
+hugo
+BASELINE=$(mktemp -d)
+cp public/blog/index.html "$BASELINE/blog-index.html.before"
+cp public/blog/job-success-profiles/index.html \
+  "$BASELINE/blog-post.html.before"
+echo "$BASELINE"
+```
+
+- [ ] **Step 2: Edit `blog/list.html`**
+
+Replace:
+
+```html
+<li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
+```
+
+With:
+
+```html
+<li class="breadcrumb-item"><a href="{{ "" | absURL }}">Home</a></li>
+```
+
+- [ ] **Step 3: Edit `blog/single.html`**
+
+Replace:
+
+```html
+<li class="breadcrumb-item"><a href={{ .Site.BaseURL }}>Home</a></li>
+<li class="breadcrumb-item"><a href={{ .Site.Params.blogPageURL | absURL }}>All Posts</a></li>
+```
+
+With:
+
+```html
+<li class="breadcrumb-item"><a href={{ "" | absURL }}>Home</a></li>
+<li class="breadcrumb-item"><a href={{ site.Params.blogPageURL | absURL }}>All Posts</a></li>
+```
+
+- [ ] **Step 4: Verify no `.Site` references remain in these two files**
+
+```bash
+grep -n '\.Site\b' themes/portio/layouts/blog/list.html \
+  themes/portio/layouts/blog/single.html
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Rebuild and diff both pages against the baseline**
+
+```bash
+hugo
+diff "$BASELINE/blog-index.html.before" public/blog/index.html
+diff "$BASELINE/blog-post.html.before" \
+  public/blog/job-success-profiles/index.html
+```
+
+Expected: no output from either diff. If there's a difference, stop and
+investigate.
+
+- [ ] **Step 6: Clean up and commit**
+
+```bash
+rm -rf "$BASELINE"
+git add themes/portio/layouts/blog/list.html \
+  themes/portio/layouts/blog/single.html
+git commit -m "Modernize blog templates to site/absURL"
+```
+
+---
+
+## Task 4: Modernize contact template
+
+**Files:**
+
+- Modify: `themes/portio/layouts/contact/list.html:30,39,116,182`
+
+Verification diffs the contact page.
+
+- [ ] **Step 1: Capture baseline output for the contact page**
+
+```bash
+hugo
+BASELINE=$(mktemp -d)
+cp public/contact/index.html "$BASELINE/contact.html.before"
+echo "$BASELINE"
+```
+
+- [ ] **Step 2: Edit `contact/list.html`**
+
+Line 30, replace:
+
+```html
+<li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
+```
+
+With:
+
+```html
+<li class="breadcrumb-item"><a href="{{ "" | absURL }}">Home</a></li>
+```
+
+Line 39, replace:
+
+```html
+{{ $address := .Site.Params.address }}
+```
+
+With:
+
+```html
+{{ $address := site.Params.address }}
+```
+
+Line 116, replace:
+
+```html
+<form id="contact-form" action="{{ .Site.Params.formspreeURL }}" method="POST">
+```
+
+With:
+
+```html
+<form id="contact-form" action="{{ site.Params.formspreeURL }}" method="POST">
+```
+
+Line 182, replace:
+
+```html
+{{ $map := .Site.Params.map }}
+```
+
+With:
+
+```html
+{{ $map := site.Params.map }}
+```
+
+- [ ] **Step 3: Verify no `.Site` references remain in this file**
+
+```bash
+grep -n '\.Site\b' themes/portio/layouts/contact/list.html
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Rebuild and diff the contact page against the baseline**
+
+```bash
+hugo
+diff "$BASELINE/contact.html.before" public/contact/index.html
+```
+
+Expected: no output. If there's a difference, stop and investigate.
+
+- [ ] **Step 5: Clean up and commit**
+
+```bash
+rm -rf "$BASELINE"
+git add themes/portio/layouts/contact/list.html
+git commit -m "Modernize contact template to site/absURL"
+```
+
+---
+
+## Task 5: Final full-site verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm zero remaining `.Site` references in the 8 scoped files**
+
+```bash
+grep -rn '\.Site\b' \
+  themes/portio/layouts/partials/head.html \
+  themes/portio/layouts/partials/navbar.html \
+  themes/portio/layouts/partials/footer.html \
+  themes/portio/layouts/partials/blogSection.html \
+  themes/portio/layouts/partials/portfolioSection.html \
+  themes/portio/layouts/blog/list.html \
+  themes/portio/layouts/blog/single.html \
+  themes/portio/layouts/contact/list.html
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Clean build with no errors or warnings**
+
+```bash
+hugo
+```
+
+Expected: exit code 0, no `WARN`/`ERROR` lines in the output.
+
+- [ ] **Step 3: Confirm the working tree is clean**
+
+```bash
+git status --short
+```
+
+Expected: no output for anything under `themes/portio/layouts` (all 8 files
+committed across Tasks 1-4). Unrelated pre-existing untracked files
+(`.agent-traces/`, `.claude/`, `.entire/`, `.hugo_build.lock`, `.wrangler/`,
+`CLAUDE.md`, `wrangler.toml`) are expected and out of scope for this plan.

--- a/docs/superpowers/specs/2026-06-30-hugo-template-modernization-design.md
+++ b/docs/superpowers/specs/2026-06-30-hugo-template-modernization-design.md
@@ -1,0 +1,78 @@
+# Hugo template modernization design
+
+## Context
+
+The `portio` theme is vendored under `themes/portio` (not a submodule). A
+previous fix (commit `d4d2e42`) brought it up to date with Hugo 0.157's actual
+breaking changes: `.Site.Data` → `hugo.Data`, `resources.ToCSS` → `css.Sass`.
+
+This round is not fixing breakage — it's adopting two idioms that Hugo's own
+docs now recommend, even though the old forms still work:
+
+- The global `site` function instead of the contextual `.Site` property,
+  since it works regardless of template scope and removes the need for
+  `$.Site` / capturing `$` purely to escape `range`/`with` scoping.
+- `absURL`/`relURL` instead of raw `.Site.BaseURL` string concatenation,
+  since direct `BaseURL` use is explicitly discouraged by Hugo's docs (it
+  doesn't handle trailing-slash or multilingual edge cases correctly).
+
+SCSS/Bootstrap/JS modernization is explicitly out of scope for this pass —
+that's a separate, later piece of work.
+
+## Scope
+
+8 files under `themes/portio/layouts`, no other parts of the repo:
+
+- `partials/navbar.html`
+- `partials/footer.html`
+- `partials/head.html`
+- `partials/blogSection.html`
+- `partials/portfolioSection.html`
+- `blog/list.html`
+- `blog/single.html`
+- `contact/list.html`
+
+## Changes
+
+### 1. `.Site.X` / `$.Site.X` → `site.X`
+
+Every contextual `.Site` access becomes the global `site` function. This
+includes `.Site.Params.*`, `.Site.Menus.*`, `.Site.RegularPages`. In
+`navbar.html`, this also removes the now-unneeded
+`{{ $menu := .Site.Menus.main }}` indirection used only to dodge `range`
+scoping — `site.Menus.main` can be called directly wherever needed.
+
+### 2. Raw `BaseURL` concatenation → `absURL`/`relURL`
+
+Five spots build URLs by concatenating `.Site.BaseURL` with a path fragment
+instead of piping through `absURL`:
+
+- Home/logo links (`navbar.html`, `blog/list.html`, `blog/single.html`,
+  `contact/list.html`): `{{ .Site.BaseURL }}` → `{{ "" | absURL }}`
+- Main nav menu loop (`navbar.html`): `{{ $.Site.BaseURL }}{{ .URL }}` →
+  `{{ .URL | absURL }}` (menu `.URL` values are plain strings from
+  `config.toml`, e.g. `"#home"`, `"blog"` — `absURL` path-joins these the
+  same way the original concatenation did)
+- Contact anchor (`navbar.html`): `{{ $.Site.BaseURL }}#contact` →
+  `{{ "#contact" | absURL }}`
+
+These are pure syntax changes — for this site's config (`baseURL` already
+ends in `/`), `absURL` produces byte-identical output to the old
+concatenation.
+
+## Non-goals
+
+- No change to rendered HTML/CSS/JS output.
+- No SCSS, Bootstrap, or JS changes (tracked separately).
+- No change to `themes/portio/exampleSite` (unused reference material, not
+  built).
+- No change to `data/*.yml` or `content/*.md`.
+
+## Testing
+
+1. `hugo` build before making changes; copy `public/` aside as a baseline.
+2. Apply the template changes.
+3. `hugo` build again.
+4. Diff the two `public/` trees for the touched pages (home, blog list/single
+   pages, contact page) — expect zero differences in generated `href`/`src`
+   values or anywhere else.

--- a/themes/portio/layouts/blog/list.html
+++ b/themes/portio/layouts/blog/list.html
@@ -27,7 +27,7 @@
 				<h3 class="breadCrumb__title">{{ .Title }}</h3>
 				<nav aria-label="breadcrumb" class="d-flex justify-content-center">
 					<ol class="breadcrumb align-items-center">
-						<li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
+						<li class="breadcrumb-item"><a href="{{ "" | absURL }}">Home</a></li>
 						<li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
 					</ol>
 				</nav>

--- a/themes/portio/layouts/blog/single.html
+++ b/themes/portio/layouts/blog/single.html
@@ -7,8 +7,8 @@
         <h3 class="breadCrumb__title">{{ .Title }}</h3>
         <nav aria-label="breadcrumb" class="d-flex justify-content-center">
           <ol class="breadcrumb align-items-center">
-            <li class="breadcrumb-item"><a href={{ .Site.BaseURL }}>Home</a></li>
-            <li class="breadcrumb-item"><a href={{ .Site.Params.blogPageURL | absURL }}>All Posts</a></li>
+            <li class="breadcrumb-item"><a href={{ "" | absURL }}>Home</a></li>
+            <li class="breadcrumb-item"><a href={{ site.Params.blogPageURL | absURL }}>All Posts</a></li>
             <li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
           </ol>
         </nav>

--- a/themes/portio/layouts/contact/list.html
+++ b/themes/portio/layouts/contact/list.html
@@ -27,7 +27,7 @@
         <h3 class="breadCrumb__title">{{ .Title }}</h3>
         <nav aria-label="breadcrumb" class="d-flex justify-content-center">
           <ol class="breadcrumb align-items-center">
-            <li class="breadcrumb-item"><a href="{{ .Site.BaseURL }}">Home</a></li>
+            <li class="breadcrumb-item"><a href="{{ "" | absURL }}">Home</a></li>
             <li class="breadcrumb-item active" aria-current="page">{{ .Params.breadcrumb }}</li>
           </ol>
         </nav>
@@ -36,7 +36,7 @@
   </div>
 </header>
 
-{{ $address := .Site.Params.address }}
+{{ $address := site.Params.address }}
 <section class="section contact__info">
   <div class="container">
     <div class="row">
@@ -113,7 +113,7 @@
           <h3>Contact Form</h3>
         </div>
         <div class="contact-form-input">
-          <form id="contact-form" action="{{ .Site.Params.formspreeURL }}" method="POST">
+          <form id="contact-form" action="{{ site.Params.formspreeURL }}" method="POST">
 
             <div class="form-row">
 
@@ -179,7 +179,7 @@
         </div>
       </div>
       <div class="col-lg-6">
-        {{ $map := .Site.Params.map }}
+        {{ $map := site.Params.map }}
         <div id="map" data-lat={{ $map.latitude }} data-long={{ $map.longitude }} data-pin={{ $map.pinImage | absURL }}>
         </div>
       </div>

--- a/themes/portio/layouts/partials/blogSection.html
+++ b/themes/portio/layouts/partials/blogSection.html
@@ -20,7 +20,7 @@
 		</div>
 
 		<div class="row">
-			{{ range first 3 (where $.Site.RegularPages "Type" "!=" "portfolio") }}
+			{{ range first 3 (where site.RegularPages "Type" "!=" "portfolio") }}
 			<div class="col-lg-4">
 				<div class="blog-preview__item">
 					<div class="blog-preview__item-thumb">

--- a/themes/portio/layouts/partials/footer.html
+++ b/themes/portio/layouts/partials/footer.html
@@ -37,7 +37,7 @@
 						<p>For any other matters (consulting, writing, comparing Marvel Snap strategies), you can drop me an email at rod@begbie.com.</p>
 					</div>
 					<div class="footer__cta_action">
-						<a class="btn btn-light btn-zoom" href="{{ .Site.Params.contactLink | absURL }}">Email me</a>
+						<a class="btn btn-light btn-zoom" href="{{ site.Params.contactLink | absURL }}">Email me</a>
 					</div>
 				</div>
 			</div>
@@ -45,14 +45,14 @@
 		<!-- <div class="row footer__widget">
 			<div class="col-lg-4">
 				<div class="footer__widget_logo mb-5">
-					<img src="{{ .Site.Params.footerLogo | absURL }}" alt="widget-logo">
+					<img src="{{ site.Params.footerLogo | absURL }}" alt="widget-logo">
 				</div>
 			</div>
 			<div class="col-lg-4">
 				<div class="text-light footer__widget_sitemap mb-5">
 					<h4 class="base-font">Sitemap</h4>
 					<ul class="unstyle-list small">
-						{{ $sitemap := .Site.Menus.sitemap }}
+						{{ $sitemap := site.Menus.sitemap }}
 						{{ range $sitemap }}
 						<li class="mb-2"><a class="text-light" href="{{ .URL | absURL }}">{{ .Name }}</a></li>
 						{{ end }}
@@ -62,7 +62,7 @@
 			<div class="col-lg-4">
 				<div class="text-light footer__widget_address mb-5">
 					<h4 class="base-font">Address</h4>
-					{{ $address := .Site.Params.address }}
+					{{ $address := site.Params.address }}
 					<ul class="fa-ul small">
 						<li class="mb-2"><a class="text-light" href="tel:{{ $address.phone }}"><span class="fa-li"><i
 										class="fa fa-phone"></i></span>{{ $address.phone }}</a></li>
@@ -78,13 +78,13 @@
 		<div class="row footer__footer">
 			<div class="col-lg-6">
 				<div class="footer__footer_copy text-light">
-					<p>{{ .Site.Params.copyright }}</p>
+					<p>{{ site.Params.copyright }}</p>
 				</div>
 			</div>
 			<div class="col-lg-6">
 				<div class="footer__footer_social">
 					<ul class="unstyle-list">
-						{{ $social := .Site.Params.social }}
+						{{ $social := site.Params.social }}
 						{{ range $social }}
 						<li class="d-inline-block mx-2"><a class="text-light" target="_blank" href="{{ .url }}"><i
 									class="fa {{ .icon }}"></i></a>
@@ -96,7 +96,7 @@
 		</div>
 	</div>
 </section>
-<!-- <script src="https://maps.googleapis.com/maps/api/js?key={{ .Site.Params.map.APIkey }}&libraries=geometry"></script> -->
+<!-- <script src="https://maps.googleapis.com/maps/api/js?key={{ site.Params.map.APIkey }}&libraries=geometry"></script> -->
 <script src="{{ "plugins/jQuery/jquery.min.js" | absURL }}"></script>
 <script src="{{ "plugins/bootstrap/bootstrap.min.js" | absURL }}"></script>
 <script src="{{ "plugins/slick/slick.min.js" | absURL }}"></script>

--- a/themes/portio/layouts/partials/head.html
+++ b/themes/portio/layouts/partials/head.html
@@ -5,7 +5,7 @@
   <meta name="og:title" content="{{ .Title }}" />
   <meta name="og:type" content="article" />
   <meta name="og:url" content="{{ .Permalink | absURL }}" />
-  {{- with .Description | default .Params.subtitle | default .Site.Params.subtitle | default .Summary }}
+  {{- with .Description | default .Params.subtitle | default site.Params.subtitle | default .Summary }}
   <meta property="og:description" content="{{ . }}">
   {{- end }}
   <meta name="twitter:card" content="summary" />

--- a/themes/portio/layouts/partials/navbar.html
+++ b/themes/portio/layouts/partials/navbar.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg fixed-top">
   <div class="container">
-    <a href="{{ .Site.BaseURL }}" class="navbar-brand">
-      <!-- <img src="{{ .Site.Params.logo | absURL }}" alt="site-logo"> -->
+    <a href="{{ "" | absURL }}" class="navbar-brand">
+      <!-- <img src="{{ site.Params.logo | absURL }}" alt="site-logo"> -->
       Rod Begbie
     </a>
     <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#navbarCollapse">
@@ -12,16 +12,15 @@
 
     <div class="collapse navbar-collapse justify-content-between" id="navbarCollapse">
       <ul class="nav navbar-nav main-navigation my-0 mx-auto">
-        {{ $menu := .Site.Menus.main }}
-        {{ range $index, $element := $menu }}
+        {{ range $index, $element := site.Menus.main }}
         <li class="nav-item">
-          <a href="{{ $.Site.BaseURL }}{{ .URL }}"
+          <a href="{{ .URL | absURL }}"
             class="nav-link text-dark text-sm-center p-2 {{ if $.IsHome }}scroll{{ end }}">{{ .Name }}</a>
         </li>
         {{ end }}
       </ul>
       <div class="navbar-nav">
-        <a href="{{ $.Site.BaseURL }}#contact" class="btn btn-primary btn-zoom hire_button">Work With Me</a>
+        <a href="{{ "#contact" | absURL }}" class="btn btn-primary btn-zoom hire_button">Work With Me</a>
       </div>
     </div>
   </div>

--- a/themes/portio/layouts/partials/portfolioSection.html
+++ b/themes/portio/layouts/partials/portfolioSection.html
@@ -13,7 +13,7 @@
     <div class="row">
       <div class="col-12">
         <div class="portfolio-item-grid">
-          {{ range (where $.Site.RegularPages "Type" "portfolio").Reverse }}
+          {{ range (where site.RegularPages "Type" "portfolio").Reverse }}
           <div class="portfolio-item">
             <img src="{{ .Params.thumbnail }}" class="portfolio-item-thumb" alt="portfolio-thumb" />
             <div class="portfolio-item-content">


### PR DESCRIPTION
## Summary

- Replace `.Site.X` template access with Hugo's recommended global `site`
  function across the vendored `portio` theme (8 files in
  `themes/portio/layouts`)
- Replace raw `.Site.BaseURL` string concatenation with `absURL` in the same
  files (home/logo links, main nav menu loop, contact anchor)
- Pure syntax refactor — zero intended change to rendered output, except one
  approved whitespace-only exception in `navbar.html` (see design doc)

Design and implementation plan are included for reference:
`docs/superpowers/specs/2026-06-30-hugo-template-modernization-design.md`
and `docs/superpowers/plans/2026-06-30-hugo-template-modernization.md`.

SCSS/Bootstrap/JS modernization is deliberately out of scope — planned as a
separate, later piece of work.

## Test plan

- [x] Each of the 4 template-editing commits was verified independently:
      `hugo` build before/after, diff of the affected generated page(s)
      against baseline, and grep confirming no `.Site` references remain
- [x] Final full-site check: zero `.Site` references across all 8 scoped
      files, clean `hugo` build, clean working tree
- [x] Independent task-by-task code review (spec compliance + quality) for
      all 4 implementation tasks — all approved
- [x] Final whole-branch review — ready to merge, no Critical/Important
      issues