### PR TITLE
Asset pipeline Phase 3: bundle, fingerprint, fix font FOUC

### DIFF
--- a/docs/superpowers/plans/2026-07-01-asset-pipeline-phase3.md
+++ b/docs/superpowers/plans/2026-07-01-asset-pipeline-phase3.md
@@ -1,0 +1,327 @@
+# Asset Pipeline Phase 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bundle the four vanilla JS modules into one fingerprinted,
+deferred file; fingerprint the existing CSS output; and fix a font-
+loading FOUC by hoisting the Google Fonts request out of a Sass
+`@import` into preconnected `<link>` tags.
+
+**Architecture:** Three independent changes to `head.html`/`footer.html`
+(plus one line removed from `_variables.scss`), each using long-stable
+Hugo Pipes functions (`resources.Concat`, `fingerprint`,
+`.Data.Integrity`). No new files, no new dependencies.
+
+**Tech Stack:** Hugo Pipes (`resources.Get`, `resources.Concat`,
+`css.Sass`, `minify`, `fingerprint`), plain HTML `<link>`/`<script>`
+attributes.
+
+## Global Constraints
+
+- No test suite exists (per `CLAUDE.md`) — verification is `hugo` build +
+  browser checks, exactly as Phases 1 and 2 did.
+- Cloudflare Pages pins Hugo 0.157.0 (`wrangler.jsonc`'s `HUGO_VERSION`);
+  local dev uses a newer version. Every task must be verified on the
+  actual Cloudflare Pages preview deploy for this branch, not only via
+  local `hugo server` — Phase 2 shipped a real bug (`Permalink` producing
+  production-anchored absolute URLs) that only appeared on the preview
+  deploy, never locally. The PR's preview URL is commented on the PR by
+  Cloudflare's bot once the branch is pushed.
+- Every asset reference must use `.RelPermalink`, never `.Permalink`, for
+  the same reason — `.Permalink` bakes in `site.BaseURL`
+  (`https://coaching.begbie.com/`), which points at production instead of
+  whatever domain is actually serving the current build.
+- No change to the behavior of any of the four JS modules or to the
+  CSS's visual output — this phase only changes packaging/delivery.
+- Every task ends with `hugo` building cleanly and zero JS console errors
+  (an SRI `integrity` mismatch shows up as a blocked resource load in the
+  console, so this check also validates the fingerprint/integrity wiring
+  is correct).
+
+---
+
+### Task 1: Bundle the four JS modules into one fingerprinted, deferred file
+
+**Files:**
+
+- Modify: `themes/portio/layouts/partials/footer.html`
+
+**Interfaces:**
+
+- Consumes: nothing from other tasks.
+- Produces: nothing later tasks depend on (Tasks 2 and 3 only touch
+  `head.html`/`_variables.scss`).
+
+- [ ] **Step 1: Replace the four individual script tags with one bundle**
+
+In `themes/portio/layouts/partials/footer.html`, replace:
+
+```html
+{{ $navbarjs := resources.Get "js/navbar.js" | minify }}
+<script src="{{ $navbarjs.RelPermalink }}"></script>
+{{ $testimonialjs := resources.Get "js/testimonial-carousel.js" | minify }}
+<script src="{{ $testimonialjs.RelPermalink }}"></script>
+{{ $videopopupjs := resources.Get "js/video-popup.js" | minify }}
+<script src="{{ $videopopupjs.RelPermalink }}"></script>
+{{ $formhandler := resources.Get "js/form-handler.js" | minify }}
+<script src="{{ $formhandler.RelPermalink }}"></script>
+```
+
+with:
+
+```html
+{{ $navbarjs := resources.Get "js/navbar.js" }}
+{{ $testimonialjs := resources.Get "js/testimonial-carousel.js" }}
+{{ $videopopupjs := resources.Get "js/video-popup.js" }}
+{{ $formhandler := resources.Get "js/form-handler.js" }}
+{{ $bundle := slice $navbarjs $testimonialjs $videopopupjs $formhandler
+  | resources.Concat "js/bundle.js" | minify | fingerprint }}
+<script defer src="{{ $bundle.RelPermalink }}"
+  integrity="{{ $bundle.Data.Integrity }}" crossorigin="anonymous"></script>
+```
+
+Note the four `resources.Get` calls no longer pipe through `minify`
+individually — `minify` now runs once on the concatenated bundle instead
+of four times on the individual files, which is both simpler and avoids
+redundant work. The bundle preserves the original load order (navbar,
+testimonial-carousel, video-popup, form-handler) exactly as the four
+separate tags did.
+
+- [ ] **Step 2: Build and verify the bundle**
+
+```bash
+cd /Users/rod/build/begbie-hugo
+rm -rf public && hugo --quiet
+ls public/js/
+```
+
+Expected: exactly one file matching `bundle.*.min.js` (a content hash in
+the filename, e.g. `bundle.a1b2c3d4.min.js`) — no `navbar.min.js`,
+`testimonial-carousel.min.js`, `video-popup.min.js`, or
+`form-handler.min.js` files present individually.
+
+- [ ] **Step 3: Confirm the fingerprint changes when content changes**
+
+```bash
+echo "// touch" >> themes/portio/assets/js/navbar.js
+rm -rf public && hugo --quiet
+ls public/js/
+git diff themes/portio/assets/js/navbar.js
+git checkout themes/portio/assets/js/navbar.js
+rm -rf public && hugo --quiet
+```
+
+Expected: the filename's hash differs between the two builds (proving
+the fingerprint is content-derived, not a fixed string), and the final
+`hugo --quiet` after `git checkout` restores the original bundle hash
+since the source is back to its original content.
+
+- [ ] **Step 4: Browser verification**
+
+Push this commit and use the `superpowers-chrome:browsing` skill against
+the Cloudflare Pages preview URL for this branch (check the PR's
+Cloudflare bot comment for the URL). On the home page:
+
+- Confirm exactly one `<script>` tag references `js/bundle.*.min.js`,
+  with both `defer` and `integrity` attributes present
+  (`{action: "eval", payload: "Array.from(document.querySelectorAll('script[src*=bundle]')).map(s => ({src: s.src, defer: s.defer, integrity: s.integrity}))"}`).
+- Re-verify all four behaviors Phase 2 built now that they're loaded from
+  one bundled file: the mobile hamburger menu opens/closes, the
+  testimonial carousel shows 2 items desktop/1 mobile with working dots
+  and autoplay, the hero video popup opens/closes, and the contact form
+  still submits successfully.
+- Check the console for zero errors (an SRI mismatch would show as a
+  blocked script load with an integrity-related error message).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add themes/portio/layouts/partials/footer.html
+git commit -m "Bundle JS modules into one fingerprinted, deferred file"
+```
+
+---
+
+### Task 2: Fingerprint the CSS output
+
+**Files:**
+
+- Modify: `themes/portio/layouts/partials/head.html`
+
+**Interfaces:**
+
+- Consumes: nothing from other tasks.
+- Produces: the exact `head.html` line range Task 3 will further modify
+  (Task 3's brief includes the post-Task-2 content as its starting
+  point).
+
+- [ ] **Step 1: Add fingerprinting and SRI to the stylesheet link**
+
+In `themes/portio/layouts/partials/head.html`, replace:
+
+```html
+  {{ "<!-- Stylesheets -->" | safeHTML }}
+  {{ $style := resources.Get "scss/style.scss" | css.Sass | minify }}
+  <link href="{{ $style.RelPermalink }}" rel="stylesheet" />
+```
+
+with:
+
+```html
+  {{ "<!-- Stylesheets -->" | safeHTML }}
+  {{ $style := resources.Get "scss/style.scss" | css.Sass | minify | fingerprint }}
+  <link href="{{ $style.RelPermalink }}" rel="stylesheet"
+    integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" />
+```
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+cd /Users/rod/build/begbie-hugo
+rm -rf public && hugo --quiet
+ls public/scss/
+```
+
+Expected: exactly one file matching `style.*.min.css` (content hash in
+the filename), no plain `style.min.css`.
+
+- [ ] **Step 3: Confirm the fingerprint changes when content changes**
+
+```bash
+echo "// touch" >> themes/portio/assets/scss/_common.scss
+rm -rf public && hugo --quiet
+ls public/scss/
+git checkout themes/portio/assets/scss/_common.scss
+rm -rf public && hugo --quiet
+```
+
+Expected: the filename's hash differs between the two builds, confirming
+it's content-derived.
+
+- [ ] **Step 4: Browser verification**
+
+Push this commit and use the `superpowers-chrome:browsing` skill against
+the Cloudflare Pages preview URL for this branch. On the home page,
+contact page, and a blog page:
+
+- Confirm the `<link rel="stylesheet">` references `scss/style.*.min.css`
+  and has an `integrity` attribute
+  (`{action: "eval", payload: "document.querySelector('link[rel=stylesheet]').outerHTML"}`).
+- Confirm the page still renders with correct styling (colors, layout,
+  fonts) — an SRI mismatch would cause the browser to refuse the
+  stylesheet entirely, which would be immediately visually obvious (an
+  unstyled page).
+- Check the console for zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add themes/portio/layouts/partials/head.html
+git commit -m "Fingerprint the compiled CSS output"
+```
+
+---
+
+### Task 3: Fix Google Fonts loading (preconnect + hoist out of the Sass @import)
+
+**Files:**
+
+- Modify: `themes/portio/layouts/partials/head.html`
+- Modify: `themes/portio/assets/scss/_variables.scss`
+
+**Interfaces:**
+
+- Consumes: `head.html`'s state after Task 2 (the stylesheet `<link>`
+  now has `| fingerprint` and an `integrity` attribute — this task adds
+  new lines immediately before that block, it doesn't touch the
+  stylesheet link itself).
+- Produces: nothing later tasks depend on (this is the last task).
+
+- [ ] **Step 1: Remove the font @import from the Sass source**
+
+In `themes/portio/assets/scss/_variables.scss`, replace:
+
+```scss
+// Fonts
+@import url("https://fonts.googleapis.com/css?family=Poppins:400,500,600,700,800,900|Yeseva+One&display=swap");
+$font-family-base: "Poppins", sans-serif;
+```
+
+with:
+
+```scss
+// Fonts
+$font-family-base: "Poppins", sans-serif;
+```
+
+(`$font-family-base` and `$headings-font-family` — the actual
+`font-family` values used throughout the theme's SCSS — are untouched;
+only the line that fetched the font *files* is removed.)
+
+- [ ] **Step 2: Add preconnect + font stylesheet link to head.html**
+
+In `themes/portio/layouts/partials/head.html`, replace:
+
+```html
+  {{ "<!-- Stylesheets -->" | safeHTML }}
+  {{ $style := resources.Get "scss/style.scss" | css.Sass | minify | fingerprint }}
+  <link href="{{ $style.RelPermalink }}" rel="stylesheet"
+    integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" />
+```
+
+with:
+
+```html
+  {{ "<!-- Fonts -->" | safeHTML }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css?family=Poppins:400,500,600,700,800,900|Yeseva+One&display=swap">
+
+  {{ "<!-- Stylesheets -->" | safeHTML }}
+  {{ $style := resources.Get "scss/style.scss" | css.Sass | minify | fingerprint }}
+  <link href="{{ $style.RelPermalink }}" rel="stylesheet"
+    integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" />
+```
+
+- [ ] **Step 3: Build and verify the @import is gone from the compiled CSS**
+
+```bash
+cd /Users/rod/build/begbie-hugo
+rm -rf public && hugo --quiet
+grep -o "fonts.googleapis.com[^)]*" public/scss/style.*.min.css || echo "no font @import in compiled CSS, as expected"
+grep -o '<link rel=preconnect[^>]*>\|<link rel=stylesheet href=https://fonts[^>]*>' public/index.html
+```
+
+Expected: the first command finds nothing in the compiled CSS (the
+`@import` is gone from the Sass source, so it can't appear in the
+output); the second command shows both `preconnect` links and the font
+stylesheet `<link>` present directly in the HTML `<head>`.
+
+- [ ] **Step 4: Browser verification**
+
+Push this commit and use the `superpowers-chrome:browsing` skill against
+the Cloudflare Pages preview URL for this branch. On the home page:
+
+- Confirm the page still renders with the correct fonts (Poppins body
+  text, Yeseva One headings) — not a fallback font. Take a full-page
+  screenshot and visually compare against a pre-Phase-3 screenshot if
+  one is available, or simply confirm the heading font looks like a
+  serif/display face (Yeseva One) rather than a generic system serif.
+- Open the browser's network panel (or use `{action: "eval", payload:
+  "performance.getEntriesByType('resource').filter(r => r.name.includes('fonts.g')).map(r => ({name: r.name, startTime: r.startTime}))"}`)
+  and confirm the Google Fonts stylesheet request's `startTime` is close
+  to the main stylesheet's `startTime` (starting in parallel), not
+  waiting until after the main stylesheet's `responseEnd` (which would
+  indicate the old @import-based waterfall is still happening somehow).
+- Check the console for zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add themes/portio/layouts/partials/head.html themes/portio/assets/scss/_variables.scss
+git commit -m "Preconnect and hoist Google Fonts out of the Sass @import"
+```

--- a/docs/superpowers/specs/2026-07-01-asset-pipeline-phase3-design.md
+++ b/docs/superpowers/specs/2026-07-01-asset-pipeline-phase3-design.md
@@ -1,0 +1,159 @@
+# Asset pipeline Phase 3: bundling, fingerprinting, font loading
+
+## Context
+
+This is Phase 3 of the 3-phase performance initiative for the vendored
+`portio` Hugo theme (`themes/portio`), following:
+
+1. **CSS trim** (done, merged) — cut unused Bootstrap SCSS, replaced Font
+   Awesome's webfont with inline SVG icons.
+2. **JS vanilla rewrite** (done, merged as `58b80fa`) — dropped jQuery,
+   Bootstrap's JS bundle, Slick, Magnific Popup, and TweenMax/GSAP in
+   favor of four small vanilla modules: `navbar.js`,
+   `testimonial-carousel.js`, `video-popup.js`, `form-handler.js`.
+3. **Asset pipeline** (this spec) — Hugo Pipes bundling/minification/
+   fingerprinting for whatever CSS/JS remains, plus a font-loading fix.
+
+## Current state
+
+- **CSS:** one file, `assets/scss/style.scss`, compiled via
+  `resources.Get "scss/style.scss" | css.Sass | minify`, loaded as a
+  single blocking `<link rel="stylesheet">` in `head.html`.
+- **JS:** four independent files under `assets/js/`, each piped through
+  `resources.Get "js/<name>.js" | minify` and loaded as its own blocking
+  `<script src="...">` tag at the end of `<body>` in `footer.html` — four
+  separate HTTP requests, no fingerprinting, no `defer`.
+- **Fonts:** Google Fonts (Poppins + Yeseva One) loaded via a plain CSS
+  `@import url(...)` inside `assets/scss/_variables.scss`, compiled
+  straight through into the final `style.min.css`. Because it's a CSS
+  `@import`, the browser can't discover or start fetching it until it has
+  already fetched and parsed the entire main stylesheet — a full extra
+  round trip before the font request even starts, on top of Google's own
+  DNS/TLS/redirect overhead. Combined with `display=swap` (already
+  present in the URL), this produces a visible flash of the fallback
+  font before swapping to Poppins/Yeseva One once it finally arrives.
+- Cloudflare Pages pins **Hugo 0.157.0** (`wrangler.jsonc`'s
+  `HUGO_VERSION`); local dev uses 0.163.3. All Hugo Pipes functions used
+  below (`resources.Concat`, `fingerprint`, `.Data.Integrity`) are long-
+  stable APIs present well before 0.157, confirmed via Hugo's own docs.
+
+## Changes
+
+### 1. JS: bundle, fingerprint, defer
+
+Concatenate the four existing JS files into one bundle, in their current
+load order, then minify and fingerprint it:
+
+```go-html-template
+{{ $navbarjs := resources.Get "js/navbar.js" }}
+{{ $testimonialjs := resources.Get "js/testimonial-carousel.js" }}
+{{ $videopopupjs := resources.Get "js/video-popup.js" }}
+{{ $formhandler := resources.Get "js/form-handler.js" }}
+{{ $bundle := slice $navbarjs $testimonialjs $videopopupjs $formhandler
+    | resources.Concat "js/bundle.js" | minify | fingerprint }}
+<script defer src="{{ $bundle.RelPermalink }}"
+  integrity="{{ $bundle.Data.Integrity }}" crossorigin="anonymous"></script>
+```
+
+This replaces the four separate `<script>` tags in `footer.html` with
+one. `defer` is safe here: every module already gates its own logic
+behind its own `DOMContentLoaded` listener, so deferring execution until
+just before that event fires changes nothing about run order or timing
+relative to what each module already does — it only lets the browser
+fetch the bundle without blocking parsing (moot at this exact position,
+since it's the last thing in `<body>`, but harmless and correct
+practice). `resources.Concat` requires all inputs share a media type,
+which four plain `.js` files already do.
+
+### 2. CSS: fingerprint only, keep blocking
+
+Per your call to avoid FOUC risk, the stylesheet's *loading behavior*
+doesn't change — still a normal blocking `<link>` in `<head>`, still the
+same `css.Sass | minify` chain. Only fingerprinting is added:
+
+```go-html-template
+{{ $style := resources.Get "scss/style.scss" | css.Sass | minify | fingerprint }}
+<link href="{{ $style.RelPermalink }}" rel="stylesheet"
+  integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" />
+```
+
+Fingerprinting means the filename changes whenever the content does
+(`style.<hash>.min.css`), which is what makes it safe to serve this file
+with far-future cache headers — a browser that already has last month's
+`style.min.css` cached will still fetch this month's the moment the hash
+changes, with no manual cache-busting needed.
+
+### 3. Fonts: preconnect + hoist out of the Sass `@import`
+
+Remove the `@import url("https://fonts.googleapis.com/css?family=...")`
+line from `assets/scss/_variables.scss` entirely. Add to `head.html`,
+before the main stylesheet `<link>`:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet"
+  href="https://fonts.googleapis.com/css?family=Poppins:400,500,600,700,800,900|Yeseva+One&display=swap">
+```
+
+The `preconnect` hints let the browser start the DNS lookup and TLS
+handshake for both Google Fonts domains (`fonts.googleapis.com` serves
+the CSS; the actual `.woff2` files come from `fonts.gstatic.com`) as soon
+as the HTML parser sees them, in parallel with everything else. Moving
+the font stylesheet `<link>` itself into `<head>` means the browser's
+preload scanner discovers and starts fetching it immediately on HTML
+parse, instead of only after the entire ~116KB main stylesheet has been
+fetched and parsed. Net effect: the font-loading waterfall
+(HTML → font CSS → font files) starts in parallel with the main
+stylesheet fetch instead of strictly after it, shortening the time to
+the font swap. `$font-family-base`/`$headings-font-family` in
+`_variables.scss` (the actual font-family declarations used throughout
+the theme's SCSS) are untouched — only the `@import` line that fetched
+the font *files* moves out.
+
+## Non-goals
+
+- No self-hosting of the font files — per your call, staying on Google's
+  CDN with `preconnect` rather than vendoring `.woff2` files.
+- No CSS code-splitting, critical-CSS extraction, or deferred/
+  non-blocking stylesheet loading — per your call, the main stylesheet
+  stays a normal blocking `<link>`.
+- No JS code-splitting or per-page bundles — all four modules are small
+  and every page loads all of them today; splitting would add
+  complexity (which pages need which bundle) for a negligible payload
+  difference at this site's scale.
+- No change to the actual behavior of any of the four JS modules or the
+  CSS's visual output — this phase only changes how these assets are
+  packaged and delivered, not what they contain.
+- No change to `config.toml`, `data/*.yml`, or `content/*.md`.
+
+## Testing/verification
+
+No test suite exists in this repo (per `CLAUDE.md`) — verification is a
+`hugo` build plus manual/browser checks, consistent with Phases 1 and 2:
+
+1. **Build weight/request-count comparison:** confirm the build emits one
+   fingerprinted JS bundle (not four separate files) and one
+   fingerprinted CSS file; confirm the filenames change if the
+   underlying content changes (rebuild after a trivial JS edit and
+   confirm the hash in the filename changes).
+2. **Browser network-panel verification:** load the home page and
+   confirmed the JS bundle loads as a single request with a `defer`
+   attribute, the CSS loads as before (blocking, in `<head>`), and the
+   Google Fonts stylesheet request starts essentially in parallel with
+   the main stylesheet request rather than after it finishes (visible in
+   the request waterfall/timing).
+3. **Functional re-verification:** re-check every behavior Phase 2 built
+   (mobile nav toggle, testimonial carousel, video popup, contact form)
+   still works correctly now that they're all loaded from one bundled,
+   fingerprinted, deferred file — bundling changes delivery, not
+   execution, but this is the cheapest place to catch an ordering
+   mistake if one exists.
+4. **Visual check:** home page, blog list/single, and contact page all
+   still render with correct fonts, styling, and no console errors
+   (particularly no SRI `integrity` mismatch errors, which would show as
+   a blocked resource load in the console).
+5. **Cloudflare Pages preview check:** given Phase 2's `RelPermalink`
+   lesson, verify this on the actual Cloudflare Pages preview deploy for
+   this branch, not only via local `hugo server` — confirm the
+   fingerprinted asset URLs and SRI hashes work correctly there too.

--- a/themes/portio/assets/scss/_variables.scss
+++ b/themes/portio/assets/scss/_variables.scss
@@ -14,7 +14,6 @@ $body-color: #7e7e8a;
 //
 
 // Fonts
-@import url("https://fonts.googleapis.com/css?family=Poppins:400,500,600,700,800,900|Yeseva+One&display=swap");
 $font-family-base: "Poppins", sans-serif;
 $headings-font-family: "Yeseva One", cursive;
 

--- a/themes/portio/layouts/partials/footer.html
+++ b/themes/portio/layouts/partials/footer.html
@@ -93,11 +93,11 @@
 		</div>
 	</div>
 </section>
-{{ $navbarjs := resources.Get "js/navbar.js" | minify }}
-<script src="{{ $navbarjs.RelPermalink }}"></script>
-{{ $testimonialjs := resources.Get "js/testimonial-carousel.js" | minify }}
-<script src="{{ $testimonialjs.RelPermalink }}"></script>
-{{ $videopopupjs := resources.Get "js/video-popup.js" | minify }}
-<script src="{{ $videopopupjs.RelPermalink }}"></script>
-{{ $formhandler := resources.Get "js/form-handler.js" | minify }}
-<script src="{{ $formhandler.RelPermalink }}"></script>
+{{ $navbarjs := resources.Get "js/navbar.js" }}
+{{ $testimonialjs := resources.Get "js/testimonial-carousel.js" }}
+{{ $videopopupjs := resources.Get "js/video-popup.js" }}
+{{ $formhandler := resources.Get "js/form-handler.js" }}
+{{ $bundle := slice $navbarjs $testimonialjs $videopopupjs $formhandler
+  | resources.Concat "js/bundle.js" | minify | fingerprint }}
+<script defer src="{{ $bundle.RelPermalink }}"
+  integrity="{{ $bundle.Data.Integrity }}" crossorigin="anonymous"></script>

--- a/themes/portio/layouts/partials/head.html
+++ b/themes/portio/layouts/partials/head.html
@@ -15,6 +15,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 
+  {{ "<!-- Fonts -->" | safeHTML }}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css?family=Poppins:400,500,600,700,800,900|Yeseva+One&display=swap">
+
   {{ "<!-- Stylesheets -->" | safeHTML }}
   {{ $style := resources.Get "scss/style.scss" | css.Sass | minify | fingerprint }}
   <link href="{{ $style.RelPermalink }}" rel="stylesheet"

--- a/themes/portio/layouts/partials/head.html
+++ b/themes/portio/layouts/partials/head.html
@@ -16,8 +16,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 
   {{ "<!-- Stylesheets -->" | safeHTML }}
-  {{ $style := resources.Get "scss/style.scss" | css.Sass | minify }}
-  <link href="{{ $style.RelPermalink }}" rel="stylesheet" />
+  {{ $style := resources.Get "scss/style.scss" | css.Sass | minify | fingerprint }}
+  <link href="{{ $style.RelPermalink }}" rel="stylesheet"
+    integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" />
 
   {{ "<!--Favicon-->" | safeHTML }}
   <link rel="shortcut icon" href="{{ "images/favicon.ico" | absURL }}" type="image/x-icon" />


### PR DESCRIPTION
## Summary

Phase 3 of the performance initiative for the vendored `portio` theme (Phase 1: CSS trim, Phase 2: JS vanilla rewrite, both merged). Bundles, fingerprints, and fixes a font-loading FOUC.

- **JS bundling:** the four vanilla modules (`navbar.js`, `testimonial-carousel.js`, `video-popup.js`, `form-handler.js`) are now concatenated into one file via `resources.Concat`, minified once, fingerprinted, and loaded as a single `<script defer integrity crossorigin>` tag — down from four separate blocking requests.
- **CSS fingerprinting:** the compiled stylesheet now gets a content-hashed filename and an SRI `integrity` attribute, same `css.Sass | minify` pipeline as before — safe for far-future cache headers, no change to loading behavior (still render-blocking, no FOUC risk).
- **Font-loading fix:** the Google Fonts (Poppins + Yeseva One) request was buried in a Sass `@import`, invisible to the browser until the entire main stylesheet had already loaded. Moved it into `<link rel="preconnect">` + a real stylesheet `<link>` in `<head>`, discovered immediately on HTML parse instead of after a full extra round trip.

Built via subagent-driven development: 3 sequential tasks, a spec-compliance + code-quality review after each (including independent verification against the live Cloudflare Pages preview, not just local builds), and a final whole-branch review.

## Test plan

- [x] `hugo --quiet` builds cleanly; emits exactly one JS bundle and one CSS file, both fingerprinted
- [x] Verified on the live Cloudflare Pages preview (pinned Hugo 0.157.0), not just locally — local 0.163.3 builds produce byte-identical fingerprint hashes to the live 0.157.0 build
- [x] SRI hashes independently recomputed against actually-served bytes and matched (a mismatch would block the resource entirely)
- [x] Mobile nav toggle, testimonial carousel, video popup, and contact form all re-verified working from the bundled/deferred JS
- [x] Font-loading timing re-measured via `performance.getEntriesByType('resource')`: the Google Fonts request and main stylesheet request now start in parallel (0ms delta) instead of sequentially
- [x] Poppins/Yeseva One render correctly (not a fallback font) on home, contact, and blog pages
- [x] Zero JS console errors throughout (verified via the browsing skill's `enable_console_logging`/`get_console_messages` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)