### PR TITLE
Little fixes: /dg review remediation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 # Generated files by hugo
 /public/
 /resources/_gen/
+.hugo_build.lock
 
 .DS_Store
+
+# Build and tooling
+.agent-traces/
+.wrangler/
+.superpowers/
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,5 +93,4 @@ first and pass only currently-existing paths.
 
 ## Deployment
 
-Cloudflare Pages, configured by `wrangler.jsonc` (the active config — `wrangler.toml` is an older
-auto-generated file, also present). `pages_build_output_dir` points at `public/`.
+Cloudflare Pages, configured by `wrangler.jsonc`. `pages_build_output_dir` points at `public/`.

--- a/config.toml
+++ b/config.toml
@@ -1,10 +1,12 @@
 baseURL = "https://coaching.begbie.com/"
 languageCode = "en-gb"
-paginate = 6
 theme = "portio"
 title = "Rod Begbie"
 enableRobotsTXT = true
 disableKinds = ["taxonomy", "term"]
+
+[pagination]
+pagerSize = 6
 
 # Main Menu
 [[menu.main]]
@@ -33,24 +35,6 @@ name = "Contact"
 url = "#contact"
 weight = 7
 
-# Sitemap Menu
-[[menu.sitemap]]
-name = "About me"
-url = "about"
-weight = 1
-[[menu.sitemap]]
-name = "Frequently Ask Question"
-url = "#"
-weight = 2
-[[menu.sitemap]]
-name = "Privacy & Policy"
-url = "#"
-weight = 3
-[[menu.sitemap]]
-name = "Latest Article"
-url = "#"
-weight = 4
-
 [params]
 blogPageURL = "blog"
 contactLink = "mailto:rod@begbie.com"
@@ -58,12 +42,6 @@ copyright = "Copyright © Rod Begbie 2026"
 footerLogo = "images/contact/widget-logo.png"
 logo = "images/site-navigation/logo.png"
 subtitle = "Software Engineering Leadership Coach"
-
-[params.address]
-address = "Barcelona, Spain"
-email = "rod@begbie.com"
-openingHours = "Open from 10am to 6pm (close at 5pm Sundays)"
-phone = "+(448) 833 5272 332"
 
 # Social icons
 

--- a/content/blog/markdown-formatting-demo.md
+++ b/content/blog/markdown-formatting-demo.md
@@ -1,8 +1,6 @@
 ---
 title: "Markdown Formatting Demo"
 date: 2020-09-13T12:49:27+06:00
-featureImage: images/allpost/allPost-6.jpg
-postImage: images/single-blog/feature-image.jpg
 draft: true
 ---
 

--- a/data/aboutSection.yml
+++ b/data/aboutSection.yml
@@ -13,5 +13,5 @@ content: >
   * His writing is featured on [LeadDev.com](https://leaddev.com/community/rod-begbie) and in O’Reilly’s [*97 Things Every Programmer Should Know:* Collective Wisdom from the Experts](https://www.oreilly.com/library/view/97-things-every/9780596809515/).
 
 button1Name: Work with me
-button1Target: #contact
+button1Target: "#contact"
 image: images/about/about-portrait.jpg

--- a/data/hero.yml
+++ b/data/hero.yml
@@ -8,7 +8,7 @@ content: >
 
   Providing coaching and mentorship to engineering leaders – from senior software engineers looking to level-up their scope of impact, to startup CTOs facing the challenges of scaling their organizations.
 buttonName: Contact me
-buttonURL: #contact
+buttonURL: "#contact"
 image: images/hero/hero-portrait.jpg
 videoThumb: images/hero/hero-video-thumb.jpg
 videoURL: https://www.youtube.com/watch?v=xnZAMk-xIGk

--- a/static/_headers
+++ b/static/_headers
@@ -14,17 +14,6 @@
 /js/*.js
   Cache-Control: public, max-age=31536000, immutable
 
-# Hugo image-processing cache: every file gets a content hash inserted before
-# the extension (`..._hu_<hash>.<ext>`). These three directories are the only
-# ones containing Hugo-processed images; each also has a couple of
-# hand-authored, non-hashed SVGs (masks/figures) that must be excluded, so we
-# match on the `_hu_` marker rather than the whole directory.
-/images/about/:base_hu_*
-  Cache-Control: public, max-age=31536000, immutable
-
-/images/hero/:base_hu_*
-  Cache-Control: public, max-age=31536000, immutable
-
 # images/writing is 100% Hugo-processed (no hand-authored files alongside).
 /images/writing/*
   Cache-Control: public, max-age=31536000, immutable

--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,30 @@
+# Cloudflare Pages custom headers.
+# https://developers.cloudflare.com/pages/configuration/headers/
+#
+# Long-lived immutable caching for content-fingerprinted build output only.
+# Do NOT add immutable rules for verbatim static files (favicons, robots.txt,
+# unprocessed images) — their filenames don't change when their content does,
+# so a stale cached copy would never be revalidated.
+
+# Fingerprinted CSS/JS bundles (theme's `fingerprint` pipe embeds a content
+# hash in the filename, e.g. style.min.<hash>.css, bundle.min.<hash>.js).
+/scss/*.css
+  Cache-Control: public, max-age=31536000, immutable
+
+/js/*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+# Hugo image-processing cache: every file gets a content hash inserted before
+# the extension (`..._hu_<hash>.<ext>`). These three directories are the only
+# ones containing Hugo-processed images; each also has a couple of
+# hand-authored, non-hashed SVGs (masks/figures) that must be excluded, so we
+# match on the `_hu_` marker rather than the whole directory.
+/images/about/:base_hu_*
+  Cache-Control: public, max-age=31536000, immutable
+
+/images/hero/:base_hu_*
+  Cache-Control: public, max-age=31536000, immutable
+
+# images/writing is 100% Hugo-processed (no hand-authored files alongside).
+/images/writing/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/themes/portio/assets/js/navbar.js
+++ b/themes/portio/assets/js/navbar.js
@@ -8,18 +8,24 @@ window.addEventListener("DOMContentLoaded", function () {
     // 350ms matches $transition-collapse in
     // themes/portio/assets/bootstrap-5.3.8/scss/_variables.scss
     var COLLAPSE_DURATION = 350;
+    // Shared handle for the pending open/close timeout. Cleared at the top
+    // of both openCollapse() and closeCollapse() so a re-click mid-transition
+    // can never let a stale timeout fire after a newer one has taken over
+    // (mirrors Bootstrap Collapse's _isTransitioning guard).
+    var pendingTimeout = null;
 
     function isOpen() {
       return collapseEl.classList.contains("show");
     }
 
     function openCollapse() {
+      window.clearTimeout(pendingTimeout);
       collapseEl.classList.remove("collapse");
       collapseEl.classList.add("collapsing");
       collapseEl.style.height = "0px";
       collapseEl.offsetHeight; // force reflow before transitioning
       collapseEl.style.height = collapseEl.scrollHeight + "px";
-      window.setTimeout(function () {
+      pendingTimeout = window.setTimeout(function () {
         collapseEl.classList.remove("collapsing");
         collapseEl.classList.add("collapse", "show");
         collapseEl.style.height = "";
@@ -29,12 +35,13 @@ window.addEventListener("DOMContentLoaded", function () {
     }
 
     function closeCollapse() {
+      window.clearTimeout(pendingTimeout);
       collapseEl.style.height = collapseEl.scrollHeight + "px";
       collapseEl.classList.remove("collapse", "show");
       collapseEl.classList.add("collapsing");
       collapseEl.offsetHeight; // force reflow before transitioning
       collapseEl.style.height = "0px";
-      window.setTimeout(function () {
+      pendingTimeout = window.setTimeout(function () {
         collapseEl.classList.remove("collapsing");
         collapseEl.classList.add("collapse");
         collapseEl.style.height = "";

--- a/themes/portio/assets/js/testimonial-carousel.js
+++ b/themes/portio/assets/js/testimonial-carousel.js
@@ -9,9 +9,14 @@ window.addEventListener("DOMContentLoaded", function () {
   var items = track.children;
   var itemCount = items.length;
   var desktopQuery = window.matchMedia("(min-width: 992px)");
+  var reducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  var pauseToggle = slider.querySelector(".testimonial__slider_pause");
   var currentIndex = 0;
   var maxIndex = 0;
   var autoplayTimer = null;
+  // True once the user has explicitly paused via the toggle button; hover
+  // and focus pausing must not resume autoplay while this is set.
+  var userPaused = false;
 
   function slidesPerView() {
     return desktopQuery.matches ? 2 : 1;
@@ -71,16 +76,54 @@ window.addEventListener("DOMContentLoaded", function () {
     window.clearInterval(autoplayTimer);
   }
 
-  function restartAutoplay() {
-    stopAutoplay();
+  // Starts autoplay unless the user has explicitly paused it via the toggle
+  // button, or the browser prefers reduced motion (in which case autoplay
+  // must never start). Used by hover/focus resume and dot navigation so
+  // neither can override an explicit user pause.
+  function maybeStartAutoplay() {
+    if (userPaused || reducedMotionQuery.matches) {
+      return;
+    }
     startAutoplay();
   }
 
+  function restartAutoplay() {
+    stopAutoplay();
+    maybeStartAutoplay();
+  }
+
+  function updatePauseToggle() {
+    if (!pauseToggle) {
+      return;
+    }
+    pauseToggle.setAttribute("aria-pressed", userPaused ? "true" : "false");
+    pauseToggle.setAttribute(
+      "aria-label",
+      userPaused ? "Play testimonials" : "Pause testimonials",
+    );
+    pauseToggle.textContent = userPaused ? "Play" : "Pause";
+  }
+
+  if (pauseToggle) {
+    pauseToggle.addEventListener("click", function () {
+      userPaused = !userPaused;
+      if (userPaused) {
+        stopAutoplay();
+      } else {
+        maybeStartAutoplay();
+      }
+      updatePauseToggle();
+    });
+  }
+
   slider.addEventListener("mouseenter", stopAutoplay);
-  slider.addEventListener("mouseleave", startAutoplay);
+  slider.addEventListener("mouseleave", maybeStartAutoplay);
+  slider.addEventListener("focusin", stopAutoplay);
+  slider.addEventListener("focusout", maybeStartAutoplay);
   desktopQuery.addEventListener("change", render);
   window.addEventListener("resize", render);
 
   render();
-  startAutoplay();
+  updatePauseToggle();
+  maybeStartAutoplay();
 });

--- a/themes/portio/assets/js/testimonial-carousel.js
+++ b/themes/portio/assets/js/testimonial-carousel.js
@@ -17,6 +17,12 @@ window.addEventListener("DOMContentLoaded", function () {
   // True once the user has explicitly paused via the toggle button; hover
   // and focus pausing must not resume autoplay while this is set.
   var userPaused = false;
+  // Track hover and focus independently so autoplay only resumes once both
+  // have cleared -- otherwise leaving with the mouse while focus is still
+  // inside (or vice versa) would resume autoplay under the still-active
+  // interaction, violating the WCAG 2.2.2 pause guarantee.
+  var isHovered = false;
+  var hasFocus = false;
 
   function slidesPerView() {
     return desktopQuery.matches ? 2 : 1;
@@ -81,7 +87,7 @@ window.addEventListener("DOMContentLoaded", function () {
   // must never start). Used by hover/focus resume and dot navigation so
   // neither can override an explicit user pause.
   function maybeStartAutoplay() {
-    if (userPaused || reducedMotionQuery.matches) {
+    if (userPaused || reducedMotionQuery.matches || isHovered || hasFocus) {
       return;
     }
     startAutoplay();
@@ -116,10 +122,22 @@ window.addEventListener("DOMContentLoaded", function () {
     });
   }
 
-  slider.addEventListener("mouseenter", stopAutoplay);
-  slider.addEventListener("mouseleave", maybeStartAutoplay);
-  slider.addEventListener("focusin", stopAutoplay);
-  slider.addEventListener("focusout", maybeStartAutoplay);
+  slider.addEventListener("mouseenter", function () {
+    isHovered = true;
+    stopAutoplay();
+  });
+  slider.addEventListener("mouseleave", function () {
+    isHovered = false;
+    maybeStartAutoplay();
+  });
+  slider.addEventListener("focusin", function () {
+    hasFocus = true;
+    stopAutoplay();
+  });
+  slider.addEventListener("focusout", function () {
+    hasFocus = false;
+    maybeStartAutoplay();
+  });
   desktopQuery.addEventListener("change", render);
   window.addEventListener("resize", render);
 

--- a/themes/portio/layouts/404.html
+++ b/themes/portio/layouts/404.html
@@ -1,0 +1,15 @@
+{{ define "main" }}
+
+<section class="section">
+  <div class="container">
+    <div class="row">
+      <div class="col-12 text-center">
+        <h1 class="breadCrumb__title">404</h1>
+        <p>Page not found</p>
+        <a class="btn btn-primary" href="{{ "/" | absURL }}">Back to homepage</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{{ end }}

--- a/themes/portio/layouts/blog/list.html
+++ b/themes/portio/layouts/blog/list.html
@@ -2,7 +2,7 @@
 
 <header class="breadCrumb">
 	<div class="svg-img">
-		<img src="images/hero/figure-svg.svg" alt="">
+		<img src={{ "images/hero/figure-svg.svg" | absURL }} alt="">
 	</div>
 	<div class="animate-shape">
 		<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 600">

--- a/themes/portio/layouts/partials/footer.html
+++ b/themes/portio/layouts/partials/footer.html
@@ -24,16 +24,16 @@
 					</div>
 					<div class="text-light footer__cta_content">
 						<h2 class="mb-0">Want to work with me?</h2>
-						<h3 class="mb-0">Coaching</h2>
+						<h3 class="mb-0">Coaching</h3>
 						<p>I combine my experience as an engineer, manager and startup co-founder with co-active life coaching techniques to guide my clients through the challenges and choices faced in the tech industry today.</p>
 						<p>If you'd like to find out more about booking me for a coaching engagement, please contact Practica.</p>
 					</div>
 					<div class="footer__cta_action">
-						<a class="btn btn-light btn-zoom" href="https://practicahq.com/coaching">Visit Practica.com</a>
+						<a class="btn btn-light btn-zoom" href="https://practicahq.com/coaching">Visit PracticaHQ.com</a>
 					</div>
 
 					<div class="text-light footer__cta_content">
-						<h3 class="mb-0">Email</h2>
+						<h3 class="mb-0">Email</h3>
 						<p>For any other matters (consulting, writing, comparing Marvel Snap strategies), you can drop me an email at rod@begbie.com.</p>
 					</div>
 					<div class="footer__cta_action">
@@ -42,37 +42,6 @@
 				</div>
 			</div>
 		</div>
-		<!-- <div class="row footer__widget">
-			<div class="col-lg-4">
-				<div class="footer__widget_logo mb-5">
-					<img src="{{ site.Params.footerLogo | absURL }}" alt="widget-logo">
-				</div>
-			</div>
-			<div class="col-lg-4">
-				<div class="text-light footer__widget_sitemap mb-5">
-					<h4 class="base-font">Sitemap</h4>
-					<ul class="unstyle-list small">
-						{{ $sitemap := site.Menus.sitemap }}
-						{{ range $sitemap }}
-						<li class="mb-2"><a class="text-light" href="{{ .URL | absURL }}">{{ .Name }}</a></li>
-						{{ end }}
-					</ul>
-				</div>
-			</div>
-			<div class="col-lg-4">
-				<div class="text-light footer__widget_address mb-5">
-					<h4 class="base-font">Address</h4>
-					{{ $address := site.Params.address }}
-					<ul class="fa-ul small">
-						<li class="mb-2"><a class="text-light" href="tel:{{ $address.phone }}"><span class="fa-li">{{ partial "icon.html" (dict "name" "fa-phone") }}</span>{{ $address.phone }}</a></li>
-						<li class="mb-2"><a class="text-light" href="mailto:{{ $address.email }}"><span class="fa-li">{{ partial "icon.html" (dict "name" "fa-envelope") }}</span>{{ $address.email }}</a></li>
-						<li class="mb-2">
-							<span class="fa-li">{{ partial "icon.html" (dict "name" "fa-map-marker") }}</span>{{ $address.address }}</a>
-						</li>
-					</ul>
-				</div>
-			</div>
-		</div> -->
 		<div class="row footer__footer">
 			<div class="col-lg-6">
 				<div class="footer__footer_copy text-light">

--- a/themes/portio/layouts/partials/head.html
+++ b/themes/portio/layouts/partials/head.html
@@ -42,7 +42,6 @@
 
   {{ "<!-- mobile responsive meta -->" | safeHTML }}
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 
   {{ "<!-- Fonts -->" | safeHTML }}
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -56,7 +55,6 @@
     integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" />
 
   {{ "<!--Favicon-->" | safeHTML }}
-  <link rel="shortcut icon" href="{{ "images/favicon.ico" | absURL }}" type="image/x-icon" />
   <link rel="icon" href="{{ "images/favicon.png" | absURL }}" type="image/x-icon" />
 
   {{ partial "structured-data.html" . }}

--- a/themes/portio/layouts/partials/resumeSection.html
+++ b/themes/portio/layouts/partials/resumeSection.html
@@ -10,11 +10,6 @@
                         <!-- <span class="top-title pre-line">{{ .topTitle }}</span> -->
                         {{ .title | markdownify }}
                     </div>
-
-                    <!-- <div class="btn-group nav mt-5">
-                        <a href="#{{.tab1Target}}" class="btn btn-primary active" data-toggle="tab">{{ .tab1Name }}</a>
-                        <a href="#{{.tab2Target}}" class="btn btn-primary" data-toggle="tab">{{ .tab2Name }}</a>
-                    </div> -->
                 </div>
             </div>
             <div class="col-lg-6">
@@ -28,16 +23,6 @@
                         </div>
                         {{ end }}
 
-                    </div>
-
-                    <div class="resume__education tab-pane" id="{{.tab2Target}}">
-                        {{ $Section := .experience }}
-                        {{ range $Section }}
-                        <div class="resume__education_item">
-                            <span class="pre-line text-primary"> {{ .time }} </span>
-                            {{ .content | markdownify }}
-                        </div>
-                        {{ end }}
                     </div>
 
                 </div>

--- a/themes/portio/layouts/partials/testimonialSection.html
+++ b/themes/portio/layouts/partials/testimonialSection.html
@@ -41,6 +41,7 @@
                     {{ end }}
                     </div>
                     <div class="testimonial__slider_dots"></div>
+                    <button type="button" class="testimonial__slider_pause btn btn-sm btn-outline-secondary" aria-pressed="false" aria-label="Pause testimonials">Pause</button>
                 </div>
             </div>
         </div>

--- a/themes/portio/layouts/shortcodes/blogsection.html
+++ b/themes/portio/layouts/shortcodes/blogsection.html
@@ -1,7 +1,0 @@
-<div class="blog-section">
-    <h3>{{ .Get "title" }}</h3>
-    <img src="{{ .Get "image" | absURL}}"  alt="blog-img">
-    <p>
-        {{ .Inner }}
-    </p>
-</div>


### PR DESCRIPTION
## Summary

Fixes the 20 confirmed findings from the adversarial (/dg) code review, executed as 4 reviewed tasks:

- **Broken contact CTAs (critical):** `buttonURL: #contact` / `button1Target: #contact` were unquoted YAML comments, so both the hero "Contact me" and about "Work with me" buttons linked to the bare homepage. Now quoted; both CTAs emit `href=".../#contact"`.
- **Real 404 page:** `404.html` was 0 bytes, so Cloudflare Pages served the homepage with HTTP 200 for every nonexistent URL (soft 404s). Now a proper template on `baseof.html`.
- **Template fixes:** duplicate viewport meta removed (the extra one blocked pinch-zoom, WCAG 1.4.4); dead `favicon.ico` link removed; footer `<h3>…</h2>` mismatches fixed; "Visit Practica.com" label corrected to PracticaHQ.com; relative SVG path on `/blog/` made absolute; dead code deleted (commented-out footer widget, unused shortcode, empty résumé experience pane).
- **Config/docs:** `paginate` → `[pagination] pagerSize`; dead `menu.sitemap` + placeholder `[params.address]` removed; `.gitignore` covers tool dirs; stale `wrangler.toml` claim dropped from CLAUDE.md; stale image front matter removed from the draft demo post.
- **JS:** navbar collapse double-click desync fixed (shared pending-timeout cleared on each toggle — previously a stale timeout could hide the menu mid-open); testimonial carousel now respects `prefers-reduced-motion`, pauses on focus as well as hover (with shared interaction state so overlapping hover+focus can't wrongly resume), and has an accessible pause/play button.
- **Caching:** new `static/_headers` gives fingerprinted CSS/JS and hashed writing images `Cache-Control: immutable`.

Contested review findings that were verified fine (og:type scope, zero-byte `_default` templates, unquoted-but-valid attributes, video-popup input handling) were deliberately left unchanged.

## Verification

- Clean-cache `hugo` and `hugo -D` builds exit 0; all changes confirmed in `public/` output.
- Each task passed an independent spec+quality review; two real bugs were caught and fixed mid-stream (carousel hover+focus overlap resume; invalid Cloudflare `:base_hu_*` placeholder syntax that would have made non-hashed SVGs immutable).
- Final whole-branch review: ready to merge, no Critical/Important findings.
- TODO on the Pages preview: `curl -I` a fingerprinted asset to confirm `_headers` takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXZUysYynWSgMkJNtG9vA