### PR TITLE
Update bio and resume, remove Practica references

### DIFF
--- a/data/aboutSection.yml
+++ b/data/aboutSection.yml
@@ -6,11 +6,11 @@ title: >
 content: >
   ### An experienced engineering leader with over two decades of product engineering and leadership experience.
 
-  * Originally from Scotland, Rod now lives in San Francisco and is a Senior Engineering Manager at Discord, and an engineering leadership coach with [Practica](https://practicahq.com/).
+  * Originally from Scotland, Rod now lives in San Francisco and is Director of Engineering for Infrastructure and Engineering Velocity at Splice, alongside independent coaching and mentorship for engineering leaders.
 
-  * Before this, he spent four years as a Senior Engineering Manager at Dropbox. Past lives have been as Co-Founder & CTO of Sosh, VP of Software Engineering at Anova Culinary, and writing code at places like Slide, Bose, and – for 39 days – Google.
+  * Before this, he led engineering for Splice Sounds, ran a TV games engineering org at Volley, and was a Senior Engineering Manager at Discord and Dropbox. Past lives have been as Co-Founder & CTO of Sosh, VP of Software Engineering at Anova Culinary, and writing code at places like Slide, Bose, and – for 39 days – Google.
 
-  * His writing is featured on [LeadDev.com](https://leaddev.com/community/rod-begbie) and in O’Reilly’s [*97 Things Every Programmer Should Know:* Collective Wisdom from the Experts](https://www.oreilly.com/library/view/97-things-every/9780596809515/).
+  * His writing is featured on [LeadDev.com](https://leaddev.com/community/rod-begbie) and in O’Reilly’s [*97 Things Every Programmer Should Know:* Collective Wisdom from the Experts](https://www.oreilly.com/library/view/97-things-every/9780596809515/), and he's spoken at conferences including LeadDev New York and Calibrate.
 
 button1Name: Work with me
 button1Target: "#contact"

--- a/data/resumeSection.yml
+++ b/data/resumeSection.yml
@@ -13,6 +13,29 @@ tab2Target: experience
 
 education:
   - content: >
+      #### Director of Engineering, Infrastructure & Engineering Velocity, _Splice_
+
+      * Leading three teams — Engineering Velocity, Data Engineering, and Site Reliability Engineering — 15 engineers and two managers, reporting to the CTO.
+
+      * Founded the Engineering Velocity team from scratch: investigated developer friction company-wide and defined four workstreams (AI Enablement, Toil & Papercuts, Ownership & Knowledge, and CI/CD) to fix it.
+
+      * Before this, led product engineering for Splice Sounds, including the release of a cross-platform VST3/AU/AAX plugin that puts Splice directly inside producers' DAWs.
+    time: 2025–Present
+  - content: >
+      #### Director of Engineering, _Volley Games_
+
+      * Led over half the company's engineering effort — five product teams, four engineering managers, 25 engineers — building voice-powered games for Roku and Fire TV.
+
+      * Turned engineering's reputation from "always late and buggy" into a team that could negotiate scope and reliably hit deadlines with quality work.
+    time: 2024–2025
+  - content: >
+      #### Senior Engineering Manager, _Discord_
+
+      * Group lead for four teams (21 engineers) shipping new in-app features for Nitro, Discord's premium subscription.
+
+      * Drove a "Progress over Perfection" culture of fast, iterative shipping — recognised with "The 80/20 Thinker" award from senior leadership.
+    time: 2022–2023
+  - content: >
       #### Senior Engineering Manager, _Dropbox_
 
       * Led teams of web, desktop and mobile engineers building _Dropbox Paper_ and _Dropbox Spaces_. Shipped tons of new functionality, hit company growth goals, and made processes like on-call manageable and less painful.

--- a/themes/portio/layouts/partials/footer.html
+++ b/themes/portio/layouts/partials/footer.html
@@ -26,10 +26,10 @@
 						<h2 class="mb-0">Want to work with me?</h2>
 						<h3 class="mb-0">Coaching</h3>
 						<p>I combine my experience as an engineer, manager and startup co-founder with co-active life coaching techniques to guide my clients through the challenges and choices faced in the tech industry today.</p>
-						<p>If you'd like to find out more about booking me for a coaching engagement, please contact Practica.</p>
+						<p>If you'd like to find out more about booking me for a coaching engagement, drop me a line.</p>
 					</div>
 					<div class="footer__cta_action">
-						<a class="btn btn-light btn-zoom" href="https://practicahq.com/coaching">Visit PracticaHQ.com</a>
+						<a class="btn btn-light btn-zoom" href="{{ site.Params.contactLink | absURL }}">Get in touch</a>
 					</div>
 
 					<div class="text-light footer__cta_content">


### PR DESCRIPTION
## Summary
- Practica shut down; removed all Practica/BestPracticer references from the site
- Rod still coaches independently, so the footer's "Coaching" CTA now points at his email instead of PracticaHQ.com
- Updated `aboutSection.yml` bio and `resumeSection.yml` timeline with recent roles: Director of Engineering (Infrastructure & Engineering Velocity) at Splice, Splice Sounds, Director of Engineering at Volley Games, and Senior Engineering Manager at Discord

## Test plan
- [x] `hugo` build succeeds with no new warnings
- [x] `grep -rli practica public/` returns no matches in the built site
- [x] Spot-checked rendered `index.html` for the new about/resume copy and footer CTA link (`mailto:rod@begbie.com`)
- [ ] Rod eyeballs the live preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BXZUysYynWSgMkJNtG9vA