### PR TITLE
Fix Hugo deprecation warnings for languageCode

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://coaching.begbie.com/"
-languageCode = "en-gb"
+locale = "en-gb"
 theme = "portio"
 title = "Rod Begbie"
 enableRobotsTXT = true

--- a/themes/portio/layouts/_default/baseof.html
+++ b/themes/portio/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.LanguageCode }}">
+<html lang="{{ site.Language.Locale }}">
 {{ partial "head.html" . }}
 
 <body>


### PR DESCRIPTION
## Summary
- Renamed `languageCode` to `locale` in `config.toml` (Hugo deprecated `languageCode` in v0.158.0)
- Updated `themes/portio/layouts/_default/baseof.html` to use `.Site.Language.Locale` instead of the deprecated `.Site.LanguageCode`

## Test plan
- [x] `rm -rf public resources/_gen .hugo_build.lock && hugo` builds with no deprecation warnings
- [x] Confirmed `<html lang="en-gb">` renders unchanged in `public/index.html`