### PR TITLE
Add Cloudflare plugin and document Pages deployment log lookup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -82,6 +82,15 @@
     ]
   },
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "cloudflare@cloudflare": true
+  },
+  "extraKnownMarketplaces": {
+    "cloudflare": {
+      "source": {
+        "source": "github",
+        "repo": "cloudflare/skills"
+      }
+    }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,3 +153,7 @@ top of the frame."
 ## Deployment
 
 Cloudflare Pages, configured by `wrangler.jsonc`. `pages_build_output_dir` points at `public/`.
+
+Pages project name is `begbie-hugo` (matches `name` in `wrangler.jsonc`). To check deployment
+status/logs, use the `cloudflare-api` MCP tool against
+`/accounts/{accountId}/pages/projects/begbie-hugo/deployments` rather than the dashboard.


### PR DESCRIPTION
## Summary
- Enable the Cloudflare plugin (`cloudflare@cloudflare`) in `.claude/settings.json`
- Document the Pages project name and how to check deployment status/logs via the `cloudflare-api` MCP tool instead of the dashboard

## Test plan
- [x] Reviewed diff, no functional site changes