### PR TITLE
Tune image quality and add AVIF variants

### DIFF
--- a/themes/portio/layouts/blog/single.html
+++ b/themes/portio/layouts/blog/single.html
@@ -27,16 +27,22 @@
                   </div>
                   {{ $anchor := .Params.featureImageAnchor | default "smart" }}
                   {{ with resources.Get .Params.featureImage }}
-                  {{ $banner700 := .Fill (printf "700x361 %s jpg q85" $anchor) }}
-                  {{ $banner1000 := .Fill (printf "1000x515 %s jpg q85" $anchor) }}
-                  {{ $banner1400 := .Fill (printf "1400x722 %s jpg q85" $anchor) }}
-                  {{ $banner2000 := .Fill (printf "2000x1031 %s jpg q85" $anchor) }}
-                  {{ $banner700Webp := .Fill (printf "700x361 %s webp q80 drawing" $anchor) }}
-                  {{ $banner1000Webp := .Fill (printf "1000x515 %s webp q80 drawing" $anchor) }}
-                  {{ $banner1400Webp := .Fill (printf "1400x722 %s webp q80 drawing" $anchor) }}
-                  {{ $banner2000Webp := .Fill (printf "2000x1031 %s webp q80 drawing" $anchor) }}
+                  {{ $banner700 := .Fill (printf "700x361 %s jpg q60" $anchor) }}
+                  {{ $banner1000 := .Fill (printf "1000x515 %s jpg q60" $anchor) }}
+                  {{ $banner1400 := .Fill (printf "1400x722 %s jpg q60" $anchor) }}
+                  {{ $banner2000 := .Fill (printf "2000x1031 %s jpg q60" $anchor) }}
+                  {{ $banner700Webp := .Fill (printf "700x361 %s webp q60 drawing" $anchor) }}
+                  {{ $banner1000Webp := .Fill (printf "1000x515 %s webp q60 drawing" $anchor) }}
+                  {{ $banner1400Webp := .Fill (printf "1400x722 %s webp q60 drawing" $anchor) }}
+                  {{ $banner2000Webp := .Fill (printf "2000x1031 %s webp q60 drawing" $anchor) }}
+                  {{ $banner700Avif := .Fill (printf "700x361 %s avif q50 drawing" $anchor) }}
+                  {{ $banner1000Avif := .Fill (printf "1000x515 %s avif q50 drawing" $anchor) }}
+                  {{ $banner1400Avif := .Fill (printf "1400x722 %s avif q50 drawing" $anchor) }}
+                  {{ $banner2000Avif := .Fill (printf "2000x1031 %s avif q50 drawing" $anchor) }}
                   {{ $sizes := "(min-width: 1400px) 1096px, (min-width: 1200px) 916px, (min-width: 992px) 736px, (min-width: 768px) 696px, (min-width: 576px) 516px, calc(100vw - 24px)" }}
                   <picture>
+                      <source type="image/avif" sizes="{{ $sizes }}"
+                          srcset="{{ $banner700Avif.RelPermalink }} 700w, {{ $banner1000Avif.RelPermalink }} 1000w, {{ $banner1400Avif.RelPermalink }} 1400w, {{ $banner2000Avif.RelPermalink }} 2000w">
                       <source type="image/webp" sizes="{{ $sizes }}"
                           srcset="{{ $banner700Webp.RelPermalink }} 700w, {{ $banner1000Webp.RelPermalink }} 1000w, {{ $banner1400Webp.RelPermalink }} 1400w, {{ $banner2000Webp.RelPermalink }} 2000w">
                       <img src="{{ $banner1000.RelPermalink }}" sizes="{{ $sizes }}"

--- a/themes/portio/layouts/partials/aboutSection.html
+++ b/themes/portio/layouts/partials/aboutSection.html
@@ -10,16 +10,22 @@
                     </div>
                     <div class="about_content-thumb-image">
                         {{ with resources.Get .image }}
-                        {{ $about500 := .Fill "500x625 Top jpg q82" }}
-                        {{ $about750 := .Fill "750x938 Top jpg q82" }}
-                        {{ $about1000 := .Fill "1000x1250 Top jpg q82" }}
-                        {{ $about1400 := .Fill "1400x1750 Top jpg q82" }}
+                        {{ $about500 := .Fill "500x625 Top jpg q75" }}
+                        {{ $about750 := .Fill "750x938 Top jpg q75" }}
+                        {{ $about1000 := .Fill "1000x1250 Top jpg q75" }}
+                        {{ $about1400 := .Fill "1400x1750 Top jpg q75" }}
                         {{ $about500Webp := .Fill "500x625 Top webp q75 picture" }}
                         {{ $about750Webp := .Fill "750x938 Top webp q75 picture" }}
                         {{ $about1000Webp := .Fill "1000x1250 Top webp q75 picture" }}
                         {{ $about1400Webp := .Fill "1400x1750 Top webp q75 picture" }}
+                        {{ $about500Avif := .Fill "500x625 Top avif q60 picture" }}
+                        {{ $about750Avif := .Fill "750x938 Top avif q60 picture" }}
+                        {{ $about1000Avif := .Fill "1000x1250 Top avif q60 picture" }}
+                        {{ $about1400Avif := .Fill "1400x1750 Top avif q60 picture" }}
                         {{ $sizes := "(min-width: 1400px) 350px, (min-width: 1200px) 300px, (min-width: 992px) 250px, (min-width: 768px) 696px, (min-width: 576px) 516px, calc(100vw - 48px)" }}
                         <picture>
+                            <source type="image/avif" sizes="{{ $sizes }}"
+                                srcset="{{ $about500Avif.RelPermalink }} 500w, {{ $about750Avif.RelPermalink }} 750w, {{ $about1000Avif.RelPermalink }} 1000w, {{ $about1400Avif.RelPermalink }} 1400w">
                             <source type="image/webp" sizes="{{ $sizes }}"
                                 srcset="{{ $about500Webp.RelPermalink }} 500w, {{ $about750Webp.RelPermalink }} 750w, {{ $about1000Webp.RelPermalink }} 1000w, {{ $about1400Webp.RelPermalink }} 1400w">
                             <img src="{{ $about750.RelPermalink }}" sizes="{{ $sizes }}"

--- a/themes/portio/layouts/partials/blogCard.html
+++ b/themes/portio/layouts/partials/blogCard.html
@@ -3,14 +3,19 @@
 	<div class="blog-preview__card_thumb">
 		{{ $anchor := $page.Params.featureImageAnchor | default "smart" }}
 		{{ with resources.Get $page.Params.featureImage }}
-		{{ $thumb400 := .Fill (printf "400x250 %s jpg q82" $anchor) }}
-		{{ $thumb600 := .Fill (printf "600x375 %s jpg q82" $anchor) }}
-		{{ $thumb900 := .Fill (printf "900x562 %s jpg q82" $anchor) }}
-		{{ $thumb400Webp := .Fill (printf "400x250 %s webp q75 drawing" $anchor) }}
-		{{ $thumb600Webp := .Fill (printf "600x375 %s webp q75 drawing" $anchor) }}
-		{{ $thumb900Webp := .Fill (printf "900x562 %s webp q75 drawing" $anchor) }}
+		{{ $thumb400 := .Fill (printf "400x250 %s jpg q60" $anchor) }}
+		{{ $thumb600 := .Fill (printf "600x375 %s jpg q60" $anchor) }}
+		{{ $thumb900 := .Fill (printf "900x562 %s jpg q60" $anchor) }}
+		{{ $thumb400Webp := .Fill (printf "400x250 %s webp q60 drawing" $anchor) }}
+		{{ $thumb600Webp := .Fill (printf "600x375 %s webp q60 drawing" $anchor) }}
+		{{ $thumb900Webp := .Fill (printf "900x562 %s webp q60 drawing" $anchor) }}
+		{{ $thumb400Avif := .Fill (printf "400x250 %s avif q50 drawing" $anchor) }}
+		{{ $thumb600Avif := .Fill (printf "600x375 %s avif q50 drawing" $anchor) }}
+		{{ $thumb900Avif := .Fill (printf "900x562 %s avif q50 drawing" $anchor) }}
 		{{ $sizes := "(min-width: 1200px) 373px, (min-width: 768px) 226px, (min-width: 576px) 516px, calc(100vw - 48px)" }}
 		<picture>
+			<source type="image/avif" sizes="{{ $sizes }}"
+				srcset="{{ $thumb400Avif.RelPermalink }} 400w, {{ $thumb600Avif.RelPermalink }} 600w, {{ $thumb900Avif.RelPermalink }} 900w">
 			<source type="image/webp" sizes="{{ $sizes }}"
 				srcset="{{ $thumb400Webp.RelPermalink }} 400w, {{ $thumb600Webp.RelPermalink }} 600w, {{ $thumb900Webp.RelPermalink }} 900w">
 			<img src="{{ $thumb600.RelPermalink }}" sizes="{{ $sizes }}"

--- a/themes/portio/layouts/partials/hero.html
+++ b/themes/portio/layouts/partials/hero.html
@@ -22,16 +22,22 @@
             {{ partial "blob.html" (dict "id" "hero-blob-gradient") }}
           </div>
           {{ with resources.Get .image }}
-          {{ $hero500 := .Fill "500x625 Top jpg q82" }}
-          {{ $hero750 := .Fill "750x938 Top jpg q82" }}
-          {{ $hero1000 := .Fill "1000x1250 Top jpg q82" }}
-          {{ $hero1400 := .Fill "1400x1750 Top jpg q82" }}
+          {{ $hero500 := .Fill "500x625 Top jpg q75" }}
+          {{ $hero750 := .Fill "750x938 Top jpg q75" }}
+          {{ $hero1000 := .Fill "1000x1250 Top jpg q75" }}
+          {{ $hero1400 := .Fill "1400x1750 Top jpg q75" }}
           {{ $hero500Webp := .Fill "500x625 Top webp q75 picture" }}
           {{ $hero750Webp := .Fill "750x938 Top webp q75 picture" }}
           {{ $hero1000Webp := .Fill "1000x1250 Top webp q75 picture" }}
           {{ $hero1400Webp := .Fill "1400x1750 Top webp q75 picture" }}
+          {{ $hero500Avif := .Fill "500x625 Top avif q60 picture" }}
+          {{ $hero750Avif := .Fill "750x938 Top avif q60 picture" }}
+          {{ $hero1000Avif := .Fill "1000x1250 Top avif q60 picture" }}
+          {{ $hero1400Avif := .Fill "1400x1750 Top avif q60 picture" }}
           {{ $sizes := "(min-width: 1400px) 500px, (min-width: 1200px) 430px, (min-width: 992px) 360px, (min-width: 768px) 696px, (min-width: 576px) 516px, calc(100vw - 24px)" }}
           <picture class="hero_figure-photo">
+            <source type="image/avif" sizes="{{ $sizes }}"
+              srcset="{{ $hero500Avif.RelPermalink }} 500w, {{ $hero750Avif.RelPermalink }} 750w, {{ $hero1000Avif.RelPermalink }} 1000w, {{ $hero1400Avif.RelPermalink }} 1400w">
             <source type="image/webp" sizes="{{ $sizes }}"
               srcset="{{ $hero500Webp.RelPermalink }} 500w, {{ $hero750Webp.RelPermalink }} 750w, {{ $hero1000Webp.RelPermalink }} 1000w, {{ $hero1400Webp.RelPermalink }} 1400w">
             <img src="{{ $hero750.RelPermalink }}" sizes="{{ $sizes }}"


### PR DESCRIPTION
## Summary
- Headshots (hero/about): jpg q82 → q75, webp stays q75, added AVIF q60
- Blog images (thumbnails/banner): jpg q82-85 → q60, webp q75-80 → q60, added AVIF q50
- `<picture>` elements now offer avif → webp → jpg fallback, in that order

## Test plan
- [x] `rm -rf public resources/_gen .hugo_build.lock && hugo` builds cleanly, no `ZgotmplZ`
- [x] Confirmed AVIF sources render first in built HTML with correct srcset
- [x] `hugo server -D`: homepage and a blog post both return 200