### PR TITLE
Fix responsive image sizes attributes to match actual rendered widths

### DIFF
--- a/themes/portio/layouts/blog/single.html
+++ b/themes/portio/layouts/blog/single.html
@@ -39,7 +39,7 @@
                   {{ $banner1000Avif := .Fill (printf "1000x515 %s avif q50 drawing" $anchor) }}
                   {{ $banner1400Avif := .Fill (printf "1400x722 %s avif q50 drawing" $anchor) }}
                   {{ $banner2000Avif := .Fill (printf "2000x1031 %s avif q50 drawing" $anchor) }}
-                  {{ $sizes := "(min-width: 1400px) 1096px, (min-width: 1200px) 916px, (min-width: 992px) 736px, (min-width: 768px) 696px, (min-width: 576px) 516px, calc(100vw - 24px)" }}
+                  {{ $sizes := "(min-width: 1280px) 1176px, calc(100vw - 104px)" }}
                   <picture>
                       <source type="image/avif" sizes="{{ $sizes }}"
                           srcset="{{ $banner700Avif.RelPermalink }} 700w, {{ $banner1000Avif.RelPermalink }} 1000w, {{ $banner1400Avif.RelPermalink }} 1400w, {{ $banner2000Avif.RelPermalink }} 2000w">

--- a/themes/portio/layouts/blog/single.html
+++ b/themes/portio/layouts/blog/single.html
@@ -39,7 +39,7 @@
                   {{ $banner1000Avif := .Fill (printf "1000x515 %s avif q50 drawing" $anchor) }}
                   {{ $banner1400Avif := .Fill (printf "1400x722 %s avif q50 drawing" $anchor) }}
                   {{ $banner2000Avif := .Fill (printf "2000x1031 %s avif q50 drawing" $anchor) }}
-                  {{ $sizes := "(min-width: 1280px) 1176px, calc(100vw - 104px)" }}
+                  {{ $sizes := "(min-width: 1280px) 1200px, calc(100vw - 80px)" }}
                   <picture>
                       <source type="image/avif" sizes="{{ $sizes }}"
                           srcset="{{ $banner700Avif.RelPermalink }} 700w, {{ $banner1000Avif.RelPermalink }} 1000w, {{ $banner1400Avif.RelPermalink }} 1400w, {{ $banner2000Avif.RelPermalink }} 2000w">

--- a/themes/portio/layouts/partials/aboutSection.html
+++ b/themes/portio/layouts/partials/aboutSection.html
@@ -22,7 +22,7 @@
                         {{ $about750Avif := .Fill "750x938 Top avif q60 picture" }}
                         {{ $about1000Avif := .Fill "1000x1250 Top avif q60 picture" }}
                         {{ $about1400Avif := .Fill "1400x1750 Top avif q60 picture" }}
-                        {{ $sizes := "(min-width: 1280px) 376px, (min-width: 992px) calc((100vw - 80px) / 3 - 24px), calc(100vw - 104px)" }}
+                        {{ $sizes := "(min-width: 1280px) 384px, (min-width: 992px) calc((100vw - 56px) / 3 - 24px), calc(100vw - 80px)" }}
                         <picture>
                             <source type="image/avif" sizes="{{ $sizes }}"
                                 srcset="{{ $about500Avif.RelPermalink }} 500w, {{ $about750Avif.RelPermalink }} 750w, {{ $about1000Avif.RelPermalink }} 1000w, {{ $about1400Avif.RelPermalink }} 1400w">

--- a/themes/portio/layouts/partials/aboutSection.html
+++ b/themes/portio/layouts/partials/aboutSection.html
@@ -22,7 +22,7 @@
                         {{ $about750Avif := .Fill "750x938 Top avif q60 picture" }}
                         {{ $about1000Avif := .Fill "1000x1250 Top avif q60 picture" }}
                         {{ $about1400Avif := .Fill "1400x1750 Top avif q60 picture" }}
-                        {{ $sizes := "(min-width: 1400px) 350px, (min-width: 1200px) 300px, (min-width: 992px) 250px, (min-width: 768px) 696px, (min-width: 576px) 516px, calc(100vw - 48px)" }}
+                        {{ $sizes := "(min-width: 1280px) 376px, (min-width: 992px) calc((100vw - 80px) / 3 - 24px), calc(100vw - 104px)" }}
                         <picture>
                             <source type="image/avif" sizes="{{ $sizes }}"
                                 srcset="{{ $about500Avif.RelPermalink }} 500w, {{ $about750Avif.RelPermalink }} 750w, {{ $about1000Avif.RelPermalink }} 1000w, {{ $about1400Avif.RelPermalink }} 1400w">

--- a/themes/portio/layouts/partials/aboutSection.html
+++ b/themes/portio/layouts/partials/aboutSection.html
@@ -10,14 +10,17 @@
                     </div>
                     <div class="about_content-thumb-image">
                         {{ with resources.Get .image }}
+                        {{ $about332 := .Fill "332x415 Top jpg q75" }}
                         {{ $about500 := .Fill "500x625 Top jpg q75" }}
                         {{ $about750 := .Fill "750x938 Top jpg q75" }}
                         {{ $about1000 := .Fill "1000x1250 Top jpg q75" }}
                         {{ $about1400 := .Fill "1400x1750 Top jpg q75" }}
+                        {{ $about332Webp := .Fill "332x415 Top webp q75 picture" }}
                         {{ $about500Webp := .Fill "500x625 Top webp q75 picture" }}
                         {{ $about750Webp := .Fill "750x938 Top webp q75 picture" }}
                         {{ $about1000Webp := .Fill "1000x1250 Top webp q75 picture" }}
                         {{ $about1400Webp := .Fill "1400x1750 Top webp q75 picture" }}
+                        {{ $about332Avif := .Fill "332x415 Top avif q60 picture" }}
                         {{ $about500Avif := .Fill "500x625 Top avif q60 picture" }}
                         {{ $about750Avif := .Fill "750x938 Top avif q60 picture" }}
                         {{ $about1000Avif := .Fill "1000x1250 Top avif q60 picture" }}
@@ -25,11 +28,11 @@
                         {{ $sizes := "(min-width: 1280px) 384px, (min-width: 992px) calc((100vw - 56px) / 3 - 24px), calc(100vw - 80px)" }}
                         <picture>
                             <source type="image/avif" sizes="{{ $sizes }}"
-                                srcset="{{ $about500Avif.RelPermalink }} 500w, {{ $about750Avif.RelPermalink }} 750w, {{ $about1000Avif.RelPermalink }} 1000w, {{ $about1400Avif.RelPermalink }} 1400w">
+                                srcset="{{ $about332Avif.RelPermalink }} 332w, {{ $about500Avif.RelPermalink }} 500w, {{ $about750Avif.RelPermalink }} 750w, {{ $about1000Avif.RelPermalink }} 1000w, {{ $about1400Avif.RelPermalink }} 1400w">
                             <source type="image/webp" sizes="{{ $sizes }}"
-                                srcset="{{ $about500Webp.RelPermalink }} 500w, {{ $about750Webp.RelPermalink }} 750w, {{ $about1000Webp.RelPermalink }} 1000w, {{ $about1400Webp.RelPermalink }} 1400w">
+                                srcset="{{ $about332Webp.RelPermalink }} 332w, {{ $about500Webp.RelPermalink }} 500w, {{ $about750Webp.RelPermalink }} 750w, {{ $about1000Webp.RelPermalink }} 1000w, {{ $about1400Webp.RelPermalink }} 1400w">
                             <img src="{{ $about750.RelPermalink }}" sizes="{{ $sizes }}"
-                                srcset="{{ $about500.RelPermalink }} 500w, {{ $about750.RelPermalink }} 750w, {{ $about1000.RelPermalink }} 1000w, {{ $about1400.RelPermalink }} 1400w"
+                                srcset="{{ $about332.RelPermalink }} 332w, {{ $about500.RelPermalink }} 500w, {{ $about750.RelPermalink }} 750w, {{ $about1000.RelPermalink }} 1000w, {{ $about1400.RelPermalink }} 1400w"
                                 width="{{ $about750.Width }}" height="{{ $about750.Height }}" alt="{{ site.Title }}" style='
                                   -webkit-mask: url({{ "images/about/about-mask-svg.svg" | absURL }});
                                   -webkit-mask-repeat: no-repeat;

--- a/themes/portio/layouts/partials/blogCard.html
+++ b/themes/portio/layouts/partials/blogCard.html
@@ -12,7 +12,7 @@
 		{{ $thumb400Avif := .Fill (printf "400x250 %s avif q50 drawing" $anchor) }}
 		{{ $thumb600Avif := .Fill (printf "600x375 %s avif q50 drawing" $anchor) }}
 		{{ $thumb900Avif := .Fill (printf "900x562 %s avif q50 drawing" $anchor) }}
-		{{ $sizes := "(min-width: 1200px) 373px, (min-width: 768px) 226px, (min-width: 576px) 516px, calc(100vw - 48px)" }}
+		{{ $sizes := "(min-width: 1280px) 376px, (min-width: 768px) calc((100vw - 152px) / 3), calc(100vw - 104px)" }}
 		<picture>
 			<source type="image/avif" sizes="{{ $sizes }}"
 				srcset="{{ $thumb400Avif.RelPermalink }} 400w, {{ $thumb600Avif.RelPermalink }} 600w, {{ $thumb900Avif.RelPermalink }} 900w">

--- a/themes/portio/layouts/partials/blogCard.html
+++ b/themes/portio/layouts/partials/blogCard.html
@@ -12,7 +12,7 @@
 		{{ $thumb400Avif := .Fill (printf "400x250 %s avif q50 drawing" $anchor) }}
 		{{ $thumb600Avif := .Fill (printf "600x375 %s avif q50 drawing" $anchor) }}
 		{{ $thumb900Avif := .Fill (printf "900x562 %s avif q50 drawing" $anchor) }}
-		{{ $sizes := "(min-width: 1280px) 376px, (min-width: 768px) calc((100vw - 152px) / 3), calc(100vw - 104px)" }}
+		{{ $sizes := "(min-width: 1280px) 384px, (min-width: 768px) calc((100vw - 56px) / 3 - 24px), calc(100vw - 80px)" }}
 		<picture>
 			<source type="image/avif" sizes="{{ $sizes }}"
 				srcset="{{ $thumb400Avif.RelPermalink }} 400w, {{ $thumb600Avif.RelPermalink }} 600w, {{ $thumb900Avif.RelPermalink }} 900w">

--- a/themes/portio/layouts/partials/blogCard.html
+++ b/themes/portio/layouts/partials/blogCard.html
@@ -3,23 +3,26 @@
 	<div class="blog-preview__card_thumb">
 		{{ $anchor := $page.Params.featureImageAnchor | default "smart" }}
 		{{ with resources.Get $page.Params.featureImage }}
+		{{ $thumb332 := .Fill (printf "332x208 %s jpg q60" $anchor) }}
 		{{ $thumb400 := .Fill (printf "400x250 %s jpg q60" $anchor) }}
 		{{ $thumb600 := .Fill (printf "600x375 %s jpg q60" $anchor) }}
 		{{ $thumb900 := .Fill (printf "900x562 %s jpg q60" $anchor) }}
+		{{ $thumb332Webp := .Fill (printf "332x208 %s webp q60 drawing" $anchor) }}
 		{{ $thumb400Webp := .Fill (printf "400x250 %s webp q60 drawing" $anchor) }}
 		{{ $thumb600Webp := .Fill (printf "600x375 %s webp q60 drawing" $anchor) }}
 		{{ $thumb900Webp := .Fill (printf "900x562 %s webp q60 drawing" $anchor) }}
+		{{ $thumb332Avif := .Fill (printf "332x208 %s avif q50 drawing" $anchor) }}
 		{{ $thumb400Avif := .Fill (printf "400x250 %s avif q50 drawing" $anchor) }}
 		{{ $thumb600Avif := .Fill (printf "600x375 %s avif q50 drawing" $anchor) }}
 		{{ $thumb900Avif := .Fill (printf "900x562 %s avif q50 drawing" $anchor) }}
 		{{ $sizes := "(min-width: 1280px) 384px, (min-width: 768px) calc((100vw - 56px) / 3 - 24px), calc(100vw - 80px)" }}
 		<picture>
 			<source type="image/avif" sizes="{{ $sizes }}"
-				srcset="{{ $thumb400Avif.RelPermalink }} 400w, {{ $thumb600Avif.RelPermalink }} 600w, {{ $thumb900Avif.RelPermalink }} 900w">
+				srcset="{{ $thumb332Avif.RelPermalink }} 332w, {{ $thumb400Avif.RelPermalink }} 400w, {{ $thumb600Avif.RelPermalink }} 600w, {{ $thumb900Avif.RelPermalink }} 900w">
 			<source type="image/webp" sizes="{{ $sizes }}"
-				srcset="{{ $thumb400Webp.RelPermalink }} 400w, {{ $thumb600Webp.RelPermalink }} 600w, {{ $thumb900Webp.RelPermalink }} 900w">
+				srcset="{{ $thumb332Webp.RelPermalink }} 332w, {{ $thumb400Webp.RelPermalink }} 400w, {{ $thumb600Webp.RelPermalink }} 600w, {{ $thumb900Webp.RelPermalink }} 900w">
 			<img src="{{ $thumb600.RelPermalink }}" sizes="{{ $sizes }}"
-				srcset="{{ $thumb400.RelPermalink }} 400w, {{ $thumb600.RelPermalink }} 600w, {{ $thumb900.RelPermalink }} 900w"
+				srcset="{{ $thumb332.RelPermalink }} 332w, {{ $thumb400.RelPermalink }} 400w, {{ $thumb600.RelPermalink }} 600w, {{ $thumb900.RelPermalink }} 900w"
 				width="{{ $thumb600.Width }}" height="{{ $thumb600.Height }}" alt="">
 		</picture>
 		{{ end }}

--- a/themes/portio/layouts/partials/hero.html
+++ b/themes/portio/layouts/partials/hero.html
@@ -22,14 +22,17 @@
             {{ partial "blob.html" (dict "id" "hero-blob-gradient") }}
           </div>
           {{ with resources.Get .image }}
+          {{ $hero332 := .Fill "332x415 Top jpg q75" }}
           {{ $hero500 := .Fill "500x625 Top jpg q75" }}
           {{ $hero750 := .Fill "750x938 Top jpg q75" }}
           {{ $hero1000 := .Fill "1000x1250 Top jpg q75" }}
           {{ $hero1400 := .Fill "1400x1750 Top jpg q75" }}
+          {{ $hero332Webp := .Fill "332x415 Top webp q75 picture" }}
           {{ $hero500Webp := .Fill "500x625 Top webp q75 picture" }}
           {{ $hero750Webp := .Fill "750x938 Top webp q75 picture" }}
           {{ $hero1000Webp := .Fill "1000x1250 Top webp q75 picture" }}
           {{ $hero1400Webp := .Fill "1400x1750 Top webp q75 picture" }}
+          {{ $hero332Avif := .Fill "332x415 Top avif q60 picture" }}
           {{ $hero500Avif := .Fill "500x625 Top avif q60 picture" }}
           {{ $hero750Avif := .Fill "750x938 Top avif q60 picture" }}
           {{ $hero1000Avif := .Fill "1000x1250 Top avif q60 picture" }}
@@ -37,11 +40,11 @@
           {{ $sizes := "(min-width: 1280px) 486px, (min-width: 992px) calc((100vw - 56px) * 5 / 12 - 24px), calc(100vw - 80px)" }}
           <picture class="hero_figure-photo">
             <source type="image/avif" sizes="{{ $sizes }}"
-              srcset="{{ $hero500Avif.RelPermalink }} 500w, {{ $hero750Avif.RelPermalink }} 750w, {{ $hero1000Avif.RelPermalink }} 1000w, {{ $hero1400Avif.RelPermalink }} 1400w">
+              srcset="{{ $hero332Avif.RelPermalink }} 332w, {{ $hero500Avif.RelPermalink }} 500w, {{ $hero750Avif.RelPermalink }} 750w, {{ $hero1000Avif.RelPermalink }} 1000w, {{ $hero1400Avif.RelPermalink }} 1400w">
             <source type="image/webp" sizes="{{ $sizes }}"
-              srcset="{{ $hero500Webp.RelPermalink }} 500w, {{ $hero750Webp.RelPermalink }} 750w, {{ $hero1000Webp.RelPermalink }} 1000w, {{ $hero1400Webp.RelPermalink }} 1400w">
+              srcset="{{ $hero332Webp.RelPermalink }} 332w, {{ $hero500Webp.RelPermalink }} 500w, {{ $hero750Webp.RelPermalink }} 750w, {{ $hero1000Webp.RelPermalink }} 1000w, {{ $hero1400Webp.RelPermalink }} 1400w">
             <img src="{{ $hero750.RelPermalink }}" sizes="{{ $sizes }}"
-              srcset="{{ $hero500.RelPermalink }} 500w, {{ $hero750.RelPermalink }} 750w, {{ $hero1000.RelPermalink }} 1000w, {{ $hero1400.RelPermalink }} 1400w"
+              srcset="{{ $hero332.RelPermalink }} 332w, {{ $hero500.RelPermalink }} 500w, {{ $hero750.RelPermalink }} 750w, {{ $hero1000.RelPermalink }} 1000w, {{ $hero1400.RelPermalink }} 1400w"
               width="{{ $hero750.Width }}" height="{{ $hero750.Height }}" fetchpriority="high"
               alt="{{ site.Title }}, {{ site.Params.subtitle }}" style='
                 -webkit-mask: url({{ "images/hero/hero-mask-svg.svg" | absURL }});

--- a/themes/portio/layouts/partials/hero.html
+++ b/themes/portio/layouts/partials/hero.html
@@ -34,7 +34,7 @@
           {{ $hero750Avif := .Fill "750x938 Top avif q60 picture" }}
           {{ $hero1000Avif := .Fill "1000x1250 Top avif q60 picture" }}
           {{ $hero1400Avif := .Fill "1400x1750 Top avif q60 picture" }}
-          {{ $sizes := "(min-width: 1400px) 500px, (min-width: 1200px) 430px, (min-width: 992px) 360px, (min-width: 768px) 696px, (min-width: 576px) 516px, calc(100vw - 24px)" }}
+          {{ $sizes := "(min-width: 1280px) 476px, (min-width: 992px) calc((100vw - 80px) * 0.4167 - 24px), calc(100vw - 104px)" }}
           <picture class="hero_figure-photo">
             <source type="image/avif" sizes="{{ $sizes }}"
               srcset="{{ $hero500Avif.RelPermalink }} 500w, {{ $hero750Avif.RelPermalink }} 750w, {{ $hero1000Avif.RelPermalink }} 1000w, {{ $hero1400Avif.RelPermalink }} 1400w">

--- a/themes/portio/layouts/partials/hero.html
+++ b/themes/portio/layouts/partials/hero.html
@@ -34,7 +34,7 @@
           {{ $hero750Avif := .Fill "750x938 Top avif q60 picture" }}
           {{ $hero1000Avif := .Fill "1000x1250 Top avif q60 picture" }}
           {{ $hero1400Avif := .Fill "1400x1750 Top avif q60 picture" }}
-          {{ $sizes := "(min-width: 1280px) 476px, (min-width: 992px) calc((100vw - 80px) * 0.4167 - 24px), calc(100vw - 104px)" }}
+          {{ $sizes := "(min-width: 1280px) 486px, (min-width: 992px) calc((100vw - 56px) * 5 / 12 - 24px), calc(100vw - 80px)" }}
           <picture class="hero_figure-photo">
             <source type="image/avif" sizes="{{ $sizes }}"
               srcset="{{ $hero500Avif.RelPermalink }} 500w, {{ $hero750Avif.RelPermalink }} 750w, {{ $hero1000Avif.RelPermalink }} 1000w, {{ $hero1400Avif.RelPermalink }} 1400w">


### PR DESCRIPTION
## Summary
- Lighthouse flagged blog thumbnails downloading at 900x562 for a 332x207 display area
- The `sizes` attributes on blog thumbnails, the blog banner, and the hero/about headshots used stale breakpoints (1200px/1400px) that don't match the site's trimmed grid (xs/sm/md/lg only, container capped at 1280px) — browsers overestimated rendered width and picked oversized srcset candidates
- Recomputed each `sizes` string from the actual grid math (1280px container cap, 40px container padding, 24px column gutter):
  - `blogCard.html`: 3-up grid ≥768px, stacked below
  - `blog/single.html` banner: always full-width `col-lg-12`
  - `hero.html`: `col-lg-5` image column ≥992px, stacked below
  - `aboutSection.html`: `col-lg-4` image column ≥992px, stacked below

## Test plan
- [x] `rm -rf public resources/_gen .hugo_build.lock && hugo` builds cleanly, no `ZgotmplZ`
- [x] Confirmed correct `sizes` strings render in built HTML for homepage (hero/about/blog cards) and single blog post (banner)
- [x] `hugo server -D`: homepage, blog list, and a blog post all return 200